### PR TITLE
moveOn posts std seq of closing xapi statements for an AU session

### DIFF
--- a/src/interfaces/MoveOnOptions.ts
+++ b/src/interfaces/MoveOnOptions.ts
@@ -1,0 +1,7 @@
+import { SendStatementOptions } from "./SendStatementOptions";
+import { ResultScore } from "@xapi/xapi/";
+
+export interface MoveOnOptions extends SendStatementOptions {
+  score?: ResultScore | number;
+  disableSendTerminated?: boolean;
+}

--- a/src/interfaces/SendStatementOptions.ts
+++ b/src/interfaces/SendStatementOptions.ts
@@ -1,4 +1,4 @@
-import { StatementTransform } from "./StatementTransform";
+import { StatementTransform } from "./";
 
 export interface SendStatementOptions {
   transform?: StatementTransform;

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -2,6 +2,7 @@ export * from "./AuthTokenResponse";
 export * from "./LaunchData";
 export * from "./LaunchParameters";
 export * from "./LearnerPreferences";
+export * from "./MoveOnOptions";
 export * from "./NumericCriteria";
 export * from "./Performance";
 export * from "./PerformanceCriteria";

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -50,6 +50,12 @@ const _setWindowLocation = (newLocation: URL | Location): void => {
   (window as any).location = newLocation;
 };
 
+export function rmProp<T extends object>(propToStrip: string, obj: T): T {
+  const res = { ...obj };
+  delete res[propToStrip];
+  return res;
+}
+
 export type MockCmi5HelperParams = Partial<
   LaunchParameters & { urlBase: string }
 >;
@@ -129,6 +135,15 @@ export class MockCmi5Helper {
             }
       )
     );
+  }
+
+  mockLaunchData(launchData: Partial<LaunchData>): void {
+    this.mockGetState({
+      data: {
+        ...this.fakeLaunchData,
+        ...launchData,
+      },
+    });
   }
 
   mockGetState(fakeResponse?: Partial<AxiosResponse>): void {


### PR DESCRIPTION
 - feature: sends PASSED and COMPLETED for scores at or above launch-data masteryScore
 - feature: sends FAILED and COMPLETED for scores below launch-data masteryScore
 - feature: does NOT send PASSED or FAILED when no score provided and launch data has masteryScore
 - feature: sets result score on COMPLETED stmt if launch data has no masteryScore
 - feature: sets result score on COMPLETED stmt if launch data has no masteryScore while preserving changes made by transform