### PR TITLE
#208: Use window.location.search instead of window.location.href

### DIFF
--- a/src/Cmi5.ts
+++ b/src/Cmi5.ts
@@ -815,7 +815,7 @@ export default class Cmi5 {
 
   private getLaunchParametersFromLMS(): LaunchParameters {
     return XAPI.getSearchQueryParamsAsObject(
-      window.location.href
+      window.location.search
     ) as LaunchParameters;
   }
 

--- a/test/__tests__/cmi5.spec.ts
+++ b/test/__tests__/cmi5.spec.ts
@@ -86,6 +86,14 @@ describe("Cmi5", () => {
     });
   });
 
+  describe("constructor with hash", () => {
+    it("parses launch params from window.location.href - url contains a hash", async () => {
+      mockCmi5.mockLocationWithHash();
+      const cmi5 = new Cmi5();
+      expect(cmi5.getLaunchParameters()).toEqual(DEFAULT_LAUNCH_PARAMETERS);
+    });
+  });
+
   describe("isCmiAvailable", () => {
     it("returns false when any required cmi query params are missing from window.location", async () => {
       expect(Cmi5.isCmiAvailable).toBe(false);

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -111,6 +111,11 @@ export class MockCmi5Helper {
   mockLocation(): void {
     _setWindowLocation(this.url);
   }
+  mockLocationWithHash(): void {
+    const url = new URL(this.url);
+    url.hash = "#this-is-a-hash";
+    _setWindowLocation(url);
+  }
 
   mockFetch(responseStatus = 200): void {
     this.mockAxios.onPost(this.fetch).reply(


### PR DESCRIPTION
Hi Christian,

Added a new test "constructor with hash" to the spec and a new mockLocationWithHash method to the helper.

I didn't change getSearchQueryParamsAsObject in the XAPI class- it splits the string by "?"- which could be an issue if there is a "?" in SearchParams - but i am not sure if that can actually ever happen.