### PR TITLE
refactor: Extract statement construction functions, use `async`/`await`, begin extracting tests.

### DIFF
--- a/src/AbstractCmi5.ts
+++ b/src/AbstractCmi5.ts
@@ -1,13 +1,11 @@
+import axios, { AxiosPromise, AxiosResponse } from "axios";
 import XAPI, {
-  Agent,
-  Context,
   InteractionActivityDefinition,
   InteractionComponent,
   LanguageMap,
   ObjectiveActivity,
   ResultScore,
   Statement,
-  StatementObject,
 } from "@xapi/xapi";
 import {
   AuthTokenResponse,
@@ -20,85 +18,58 @@ import {
   Period,
   MoveOnOptions,
   NumericCriteria,
-  NumericExact,
-  NumericRange,
   SendStatementOptions,
 } from "./interfaces";
-import { Cmi5DefinedVerbs, Cmi5ContextActivity } from "./constants";
-import { default as deepmerge } from "deepmerge";
-import axios, { AxiosPromise, AxiosResponse } from "axios";
-import { v4 as uuidv4 } from "uuid";
-import { Cmi5InteractionStatement, Cmi5ProgressStatement } from "Cmi5Statements";
+import { Cmi5DefinedVerbs } from "./constants";
+import {
+  Cmi5CompleteStatement,
+  Cmi5DefinedStatement,
+  Cmi5FailStatement,
+  Cmi5InteractionChoiceStatement,
+  Cmi5InteractionFillInStatement,
+  Cmi5InteractionLikertStatement,
+  Cmi5InteractionLongFillInStatement,
+  Cmi5InteractionMatchingStatement,
+  Cmi5InteractionNumericStatement,
+  Cmi5InteractionOtherStatement,
+  Cmi5InteractionPerformanceStatement,
+  Cmi5InteractionSequencingStatement,
+  Cmi5InteractionStatement,
+  Cmi5InteractionTrueFalseStatement,
+  Cmi5MoveOnStatements,
+  Cmi5MoveOnStatementSendOptions,
+  Cmi5PassStatement,
+  Cmi5ProgressStatement,
+  Cmi5TerminateStatement,
+} from "./Cmi5Statements";
 
 export * from "./interfaces";
-
-function _isObjectiveActivity(x?: any): boolean {
-  return (
-    x &&
-    x.objectType === "Activity" &&
-    typeof x.id === "string" &&
-    x.definition &&
-    typeof x.definition === "object" &&
-    x.definition.type === "http://adlnet.gov/expapi/activities/objective"
-  );
-}
-
-function _toResultScore(s?: ResultScore | number): ResultScore | undefined {
-  return !isNaN(Number(s))
-    ? {
-        scaled: Number(s),
-      }
-    : (s as ResultScore);
-}
-
-function isNumericExact(candidate: unknown): candidate is NumericExact {
-  return typeof candidate === "object" && "exact" in candidate;
-}
-
-function isNumericRange(candidate: unknown): candidate is NumericRange {
-  return (
-    typeof candidate === "object" && "min" in candidate && "max" in candidate
-  );
-}
-
-function numericCriteriaToString(
-  criteria: NumericExact | NumericRange | unknown
-) {
-  if (isNumericExact(criteria)) {
-    return String(criteria.exact);
-  } else if (isNumericRange(criteria)) {
-    const { min, max } = criteria;
-    return `${min}:${max}`;
-  } else {
-    return ":";
-  }
-}
 
 /**
  * Experience API cmi5 Profile (Quartz - 1st Edition)
  * Reference: https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md
  */
 export default class AbstractCmi5 {
-  private launchParameters: LaunchParameters;
-  private launchData!: LaunchData;
-  private learnerPreferences!: LearnerPreferences;
-  private initializedDate!: Date;
-  private authToken: string | null = null;
+  private _launchParameters: LaunchParameters;
+  private _launchData!: LaunchData;
+  private _learnerPreferences!: LearnerPreferences;
+  private _initializedDate!: Date;
+  private _authToken: string | null = null;
   private _xapi: XAPI;
 
   constructor(launchParameters: LaunchParameters) {
-    this.launchParameters = launchParameters;
-    if (!this.launchParameters.fetch) {
+    this._launchParameters = launchParameters;
+    if (!this._launchParameters.fetch) {
       throw Error("Unable to construct, no `fetch` parameter found in URL.");
-    } else if (!this.launchParameters.endpoint) {
+    } else if (!this._launchParameters.endpoint) {
       throw Error("Unable to construct, no `endpoint` parameter found in URL");
-    } else if (!this.launchParameters.actor) {
+    } else if (!this._launchParameters.actor) {
       throw Error("Unable to construct, no `actor` parameter found in URL.");
-    } else if (!this.launchParameters.activityId) {
+    } else if (!this._launchParameters.activityId) {
       throw Error(
         "Unable to construct, no `activityId` parameter found in URL."
       );
-    } else if (!this.launchParameters.registration) {
+    } else if (!this._launchParameters.registration) {
       throw Error(
         "Unable to construct, no `registration` parameter found in URL."
       );
@@ -113,26 +84,38 @@ export default class AbstractCmi5 {
     return Boolean(this._xapi);
   }
 
+  public get launchParameters(): LaunchParameters | null {
+    return this._launchParameters;
+  }
+
   public getLaunchParameters(): LaunchParameters {
-    return this.launchParameters;
+    return this._launchParameters;
+  }
+
+  public get launchData(): LaunchData {
+    return this._launchData;
   }
 
   public getLaunchData(): LaunchData {
-    return this.launchData;
+    return this._launchData;
   }
 
   // Best Practice #17 – Persist AU Session State - https://aicc.github.io/CMI-5_Spec_Current/best_practices/
   public getAuthToken(): string {
-    return this.authToken;
+    return this._authToken;
+  }
+
+  public get initializedDate(): Date {
+    return this._initializedDate;
   }
 
   public getInitializedDate(): Date {
-    return this.initializedDate;
+    return this._initializedDate;
   }
 
   // 11.0 xAPI Agent Profile Data Model - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#110-xapi-agent-profile-data-model
   public getLearnerPreferences(): LearnerPreferences {
-    return this.learnerPreferences;
+    return this._learnerPreferences;
   }
 
   // "cmi5 defined" Statements
@@ -141,191 +124,60 @@ export default class AbstractCmi5 {
     initializedDate: Date;
   }): AxiosPromise<string[] | void> {
     // Best Practice #17 – Persist AU Session State - https://aicc.github.io/CMI-5_Spec_Current/best_practices/
-    const authToken = sessionState ? sessionState.authToken : (await this.getAuthTokenFromLMS(this.launchParameters.fetch));
-    this.authToken = authToken;
+    const authToken = sessionState
+      ? sessionState.authToken
+      : await this.getAuthTokenFromLMS(this._launchParameters.fetch);
+    this._authToken = authToken;
     this._xapi = new XAPI({
-      endpoint: this.launchParameters.endpoint,
+      endpoint: this._launchParameters.endpoint,
       auth: `Basic ${authToken}`,
     });
-    this.launchData = await this.getLaunchDataFromLMS();
-    this.learnerPreferences = await this.getLearnerPreferencesFromLMS();
+    this._launchData = await this.getLaunchDataFromLMS();
+    this._learnerPreferences = await this.getLearnerPreferencesFromLMS();
 
     if (sessionState) {
       // Best Practice #17 – Persist AU Session State - https://aicc.github.io/CMI-5_Spec_Current/best_practices/
-      this.initializedDate = sessionState.initializedDate;
+      this._initializedDate = sessionState.initializedDate;
     } else {
-      this.initializedDate = new Date();
+      this._initializedDate = new Date();
       // 9.3.2 Initialized - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#932-initialized
-      return this.sendCmi5DefinedStatement({
+      const statement = Cmi5DefinedStatement(this, {
         verb: Cmi5DefinedVerbs.INITIALIZED,
       });
+      return this.sendXapiStatement(statement);
     }
   }
 
   public complete(options?: SendStatementOptions): AxiosPromise<string[]> {
-    // 10.0 xAPI State Data Model - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#100-xapi-state-data-model
-    if (this.launchData.launchMode !== "Normal")
-      return Promise.reject(
-        new Error("Can only send COMPLETED when launchMode is 'Normal'")
-      );
-    return this.sendCmi5DefinedStatement(
-      {
-        // 9.3.3 Completed - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#933-completed
-        verb: Cmi5DefinedVerbs.COMPLETED,
-        result: {
-          // 9.5.3 Completion - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#953-completion
-          completion: true,
-          // 9.5.4.1 Duration - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#completed-statement
-          duration: XAPI.calculateISO8601Duration(
-            this.initializedDate,
-            new Date()
-          ),
-        },
-        context: {
-          contextActivities: {
-            category: [
-              // 9.6.2.2 moveOn Category Activity - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#9622-moveon-category-activity
-              Cmi5ContextActivity.MOVE_ON,
-            ],
-          },
-        },
-      },
-      options
-    );
+    const statement = Cmi5CompleteStatement(this);
+    return this.sendXapiStatement(statement, options);
   }
 
   public pass(
     score?: ResultScore | number,
     objectiveOrOptions?: ObjectiveActivity | PassOptions
   ): AxiosPromise<string[]> {
-    // 10.0 xAPI State Data Model - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#100-xapi-state-data-model
-    if (this.launchData.launchMode !== "Normal")
-      return Promise.reject(
-        new Error("Can only send PASSED when launchMode is 'Normal'")
-      );
-    const rScore = _toResultScore(score);
-    // Best Practice #4 - AU Mastery Score - https://aicc.github.io/CMI-5_Spec_Current/best_practices/
-    if (
-      this.launchData.masteryScore &&
-      (!rScore ||
-        isNaN(Number(rScore.scaled)) ||
-        rScore.scaled < this.launchData.masteryScore)
-    )
-      return Promise.reject(new Error("Learner has not met Mastery Score"));
-    const [objective, options] = _isObjectiveActivity(objectiveOrOptions)
-      ? [objectiveOrOptions as ObjectiveActivity, undefined]
-      : [
-          (objectiveOrOptions as PassOptions)
-            ? (objectiveOrOptions as PassOptions).objectiveActivity
-            : undefined,
-          objectiveOrOptions as SendStatementOptions,
-        ];
-    return this.sendCmi5DefinedStatement(
-      {
-        // 9.3.4 Passed - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#934-passed
-        verb: Cmi5DefinedVerbs.PASSED,
-        result: {
-          // 9.5.1 Score - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#951-score
-          ...(rScore ? { score: rScore } : {}),
-          // 9.5.2 Success - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#952-success
-          success: true,
-          // 9.5.4.1 Duration - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#passed-statement
-          duration: XAPI.calculateISO8601Duration(
-            this.initializedDate,
-            new Date()
-          ),
-        },
-        context: {
-          contextActivities: {
-            category: [
-              // 9.6.2.2 moveOn Category Activity - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#9622-moveon-category-activity
-              Cmi5ContextActivity.MOVE_ON,
-            ],
-            // Best Practice #1 - Use of Objectives - https://aicc.github.io/CMI-5_Spec_Current/best_practices/
-            ...(objective
-              ? {
-                  parent: [objective as ObjectiveActivity],
-                }
-              : {}),
-          },
-          ...(this.launchData.masteryScore
-            ? {
-                extensions: {
-                  "https://w3id.org/xapi/cmi5/context/extensions/masteryscore":
-                    this.launchData.masteryScore,
-                },
-              }
-            : {}),
-        },
-      },
-      options
-    );
+    const statement = Cmi5PassStatement(this, score, objectiveOrOptions);
+    return this.sendXapiStatement(statement, objectiveOrOptions as PassOptions);
   }
 
   public fail(
     score?: ResultScore | number,
     options?: SendStatementOptions
   ): AxiosPromise<string[]> {
-    // 10.0 xAPI State Data Model - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#100-xapi-state-data-model
-    if (this.launchData.launchMode !== "Normal")
-      return Promise.reject(
-        new Error("Can only send FAILED when launchMode is 'Normal'")
-      );
-    const rScore = _toResultScore(score);
-    return this.sendCmi5DefinedStatement(
-      {
-        // 9.3.5 Failed - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#935-failed
-        verb: Cmi5DefinedVerbs.FAILED,
-        result: {
-          // 9.5.1 Score - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#951-score
-          ...(rScore ? { score: rScore } : {}),
-          // 9.5.2 Success - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#952-success
-          success: false,
-          // 9.5.4.1 Duration - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#failed-statement
-          duration: XAPI.calculateISO8601Duration(
-            this.initializedDate,
-            new Date()
-          ),
-        },
-        context: {
-          contextActivities: {
-            category: [
-              // 9.6.2.2 moveOn Category Activity - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#9622-moveon-category-activity
-              Cmi5ContextActivity.MOVE_ON,
-            ],
-          },
-          ...(this.launchData.masteryScore
-            ? {
-                extensions: {
-                  "https://w3id.org/xapi/cmi5/context/extensions/masteryscore":
-                    this.launchData.masteryScore,
-                },
-              }
-            : {}),
-        },
-      },
-      options
-    );
+    const statement = Cmi5FailStatement(this, score);
+    return this.sendXapiStatement(statement, options);
   }
 
   public terminate(): AxiosPromise<string[]> {
-    return this.sendCmi5DefinedStatement({
-      // 9.3.8 Terminated - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#938-terminated
-      verb: Cmi5DefinedVerbs.TERMINATED,
-      result: {
-        // 9.5.4.1 Duration - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#terminated-statement
-        duration: XAPI.calculateISO8601Duration(
-          this.initializedDate,
-          new Date()
-        ),
-      },
-    });
+    const statement = Cmi5TerminateStatement(this);
+    return this.sendXapiStatement(statement);
   }
 
   // "cmi5 allowed" Statements
   public progress(percent: number): AxiosPromise<string[]> {
-    const statement = Cmi5ProgressStatement(this.launchParameters, percent);
-    return this.sendCmi5AllowedStatement(statement);
+    const statement = Cmi5ProgressStatement(this, percent);
+    return this.sendXapiStatement(statement);
   }
 
   public interactionTrueFalse(
@@ -339,25 +191,19 @@ export default class AbstractCmi5 {
     duration?: Period,
     objective?: ObjectiveActivity
   ): AxiosPromise<string[]> {
-    return this.interaction(
+    const statement = Cmi5InteractionTrueFalseStatement(
+      this,
       testId,
       questionId,
-      answer.toString(),
-      {
-        type: "http://adlnet.gov/expapi/activities/cmi.interaction",
-        interactionType: "true-false",
-        ...(correctAnswer !== undefined
-          ? {
-              correctResponsesPattern: correctAnswer ? ["true"] : ["false"],
-            }
-          : {}),
-        ...(name ? { name } : {}),
-        ...(description ? { description } : {}),
-      },
+      answer,
+      correctAnswer,
+      name,
+      description,
       success,
       duration,
       objective
     );
+    return this.sendXapiStatement(statement);
   }
 
   public interactionChoice(
@@ -372,26 +218,20 @@ export default class AbstractCmi5 {
     duration?: Period,
     objective?: ObjectiveActivity
   ): AxiosPromise<string[]> {
-    return this.interaction(
+    const statement = Cmi5InteractionChoiceStatement(
+      this,
       testId,
       questionId,
-      answerIds.join("[,]"),
-      {
-        type: "http://adlnet.gov/expapi/activities/cmi.interaction",
-        interactionType: "choice",
-        ...(correctAnswerIds
-          ? {
-              correctResponsesPattern: [correctAnswerIds.join("[,]")],
-            }
-          : {}),
-        ...(choices ? { choices } : {}),
-        ...(name ? { name } : {}),
-        ...(description ? { description } : {}),
-      },
+      answerIds,
+      correctAnswerIds,
+      choices,
+      name,
+      description,
       success,
       duration,
       objective
     );
+    return this.sendXapiStatement(statement);
   }
 
   public interactionFillIn(
@@ -405,25 +245,19 @@ export default class AbstractCmi5 {
     duration?: Period,
     objective?: ObjectiveActivity
   ): AxiosPromise<string[]> {
-    return this.interaction(
+    const statement = Cmi5InteractionFillInStatement(
+      this,
       testId,
       questionId,
-      answers.join("[,]"),
-      {
-        type: "http://adlnet.gov/expapi/activities/cmi.interaction",
-        interactionType: "fill-in",
-        ...(correctAnswers
-          ? {
-              correctResponsesPattern: [correctAnswers.join("[,]")],
-            }
-          : {}),
-        ...(name ? { name } : {}),
-        ...(description ? { description } : {}),
-      },
+      answers,
+      correctAnswers,
+      name,
+      description,
       success,
       duration,
       objective
     );
+    return this.sendXapiStatement(statement);
   }
 
   public interactionLongFillIn(
@@ -437,25 +271,19 @@ export default class AbstractCmi5 {
     duration?: Period,
     objective?: ObjectiveActivity
   ): AxiosPromise<string[]> {
-    return this.interaction(
+    const statement = Cmi5InteractionLongFillInStatement(
+      this,
       testId,
       questionId,
-      answers.join("[,]"),
-      {
-        type: "http://adlnet.gov/expapi/activities/cmi.interaction",
-        interactionType: "long-fill-in",
-        ...(correctAnswers
-          ? {
-              correctResponsesPattern: [correctAnswers.join("[,]")],
-            }
-          : {}),
-        ...(name ? { name } : {}),
-        ...(description ? { description } : {}),
-      },
+      answers,
+      correctAnswers,
+      name,
+      description,
       success,
       duration,
       objective
     );
+    return this.sendXapiStatement(statement);
   }
 
   public interactionLikert(
@@ -470,26 +298,20 @@ export default class AbstractCmi5 {
     duration?: Period,
     objective?: ObjectiveActivity
   ): AxiosPromise<string[]> {
-    return this.interaction(
+    const statement = Cmi5InteractionLikertStatement(
+      this,
       testId,
       questionId,
       answerId,
-      {
-        type: "http://adlnet.gov/expapi/activities/cmi.interaction",
-        interactionType: "likert",
-        ...(correctAnswerId
-          ? {
-              correctResponsesPattern: [correctAnswerId],
-            }
-          : {}),
-        ...(scale ? { scale } : {}),
-        ...(name ? { name } : {}),
-        ...(description ? { description } : {}),
-      },
+      correctAnswerId,
+      scale,
+      name,
+      description,
       success,
       duration,
       objective
     );
+    return this.sendXapiStatement(statement);
   }
 
   public interactionMatching(
@@ -505,33 +327,21 @@ export default class AbstractCmi5 {
     duration?: Period,
     objective?: ObjectiveActivity
   ): AxiosPromise<string[]> {
-    return this.interaction(
+    const statement = Cmi5InteractionMatchingStatement(
+      this,
       testId,
       questionId,
-      Object.entries(answers)
-        .map(([k, v]) => `${k}[.]${v}`)
-        .join("[,]"),
-      {
-        type: "http://adlnet.gov/expapi/activities/cmi.interaction",
-        interactionType: "matching",
-        ...(correctAnswers
-          ? {
-              correctResponsesPattern: [
-                Object.entries(correctAnswers)
-                  .map(([key, val]) => `${key}[.]${val}`)
-                  .join("[,]"),
-              ],
-            }
-          : {}),
-        ...(source ? { source } : {}),
-        ...(target ? { target } : {}),
-        ...(name ? { name } : {}),
-        ...(description ? { description } : {}),
-      },
+      answers,
+      correctAnswers,
+      source,
+      target,
+      name,
+      description,
       success,
       duration,
       objective
     );
+    return this.sendXapiStatement(statement);
   }
 
   public interactionPerformance(
@@ -546,32 +356,20 @@ export default class AbstractCmi5 {
     duration?: Period,
     objective?: ObjectiveActivity
   ): AxiosPromise<string[]> {
-    return this.interaction(
+    const statement = Cmi5InteractionPerformanceStatement(
+      this,
       testId,
       questionId,
-      Object.entries(answers)
-        .map(([k, v]) => `${k}[.]${v}`)
-        .join("[,]"),
-      {
-        type: "http://adlnet.gov/expapi/activities/cmi.interaction",
-        interactionType: "performance",
-        ...(correctAnswers
-          ? {
-              correctResponsesPattern: [
-                Object.entries(correctAnswers)
-                  .map(([k, v]) => `${k}[.]${numericCriteriaToString(v)}`)
-                  .join("[,]"),
-              ],
-            }
-          : {}),
-        ...(steps ? { steps } : {}),
-        ...(name ? { name } : {}),
-        ...(description ? { description } : {}),
-      },
+      answers,
+      correctAnswers,
+      steps,
+      name,
+      description,
       success,
       duration,
       objective
     );
+    return this.sendXapiStatement(statement);
   }
 
   public interactionSequencing(
@@ -586,26 +384,20 @@ export default class AbstractCmi5 {
     duration?: Period,
     objective?: ObjectiveActivity
   ): AxiosPromise<string[]> {
-    return this.interaction(
+    const statement = Cmi5InteractionSequencingStatement(
+      this,
       testId,
       questionId,
-      answerIds.join("[,]"),
-      {
-        type: "http://adlnet.gov/expapi/activities/cmi.interaction",
-        interactionType: "sequencing",
-        ...(correctAnswerIds
-          ? {
-              correctResponsesPattern: [correctAnswerIds.join("[,]")],
-            }
-          : {}),
-        ...(choices ? { choices } : {}),
-        ...(name ? { name } : {}),
-        ...(description ? { description } : {}),
-      },
+      answerIds,
+      correctAnswerIds,
+      choices,
+      name,
+      description,
       success,
       duration,
       objective
     );
+    return this.sendXapiStatement(statement);
   }
 
   public interactionNumeric(
@@ -619,24 +411,19 @@ export default class AbstractCmi5 {
     duration?: Period,
     objective?: ObjectiveActivity
   ): AxiosPromise<string[]> {
-    const correctAnswerObj = correctAnswer
-      ? { correctResponsesPattern: [numericCriteriaToString(correctAnswer)] }
-      : {};
-    return this.interaction(
+    const statement = Cmi5InteractionNumericStatement(
+      this,
       testId,
       questionId,
-      answer.toString(),
-      {
-        type: "http://adlnet.gov/expapi/activities/cmi.interaction",
-        interactionType: "numeric",
-        ...correctAnswerObj,
-        ...(name ? { name } : {}),
-        ...(description ? { description } : {}),
-      },
+      answer,
+      correctAnswer,
+      name,
+      description,
       success,
       duration,
       objective
     );
+    return this.sendXapiStatement(statement);
   }
 
   public interactionOther(
@@ -650,25 +437,20 @@ export default class AbstractCmi5 {
     duration?: Period,
     objective?: ObjectiveActivity
   ): AxiosPromise<string[]> {
-    return this.interaction(
+    const statement = Cmi5InteractionOtherStatement(
+      this,
       testId,
       questionId,
       answer,
-      {
-        type: "http://adlnet.gov/expapi/activities/cmi.interaction",
-        interactionType: "other",
-        ...(correctAnswer
-          ? {
-              correctResponsesPattern: [correctAnswer],
-            }
-          : {}),
-        ...(name ? { name } : {}),
-        ...(description ? { description } : {}),
-      },
+      correctAnswer,
+      name,
+      description,
       success,
       duration,
       objective
     );
+
+    return this.sendXapiStatement(statement);
   }
 
   public interaction(
@@ -681,7 +463,7 @@ export default class AbstractCmi5 {
     objective?: ObjectiveActivity
   ): AxiosPromise<string[]> {
     const statement = Cmi5InteractionStatement(
-      this.launchParameters,
+      this,
       testId,
       questionId,
       response,
@@ -690,63 +472,16 @@ export default class AbstractCmi5 {
       duration,
       objective
     );
-    return this.sendCmi5AllowedStatement(statement);
-  }
-
-  private setResultScore(resultScore: ResultScore, s: Statement): Statement {
-    return {
-      ...s,
-      result: {
-        ...(s.result || {}),
-        score: resultScore,
-      },
-    };
+    return this.sendXapiStatement(statement);
   }
 
   public async moveOn(options?: MoveOnOptions): Promise<string[]> {
-    let effectiveOptions = options;
-    // 10.0 xAPI State Data Model - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#100-xapi-state-data-model
-    if (this.launchData.launchMode !== "Normal")
-      return Promise.reject(
-        new Error("Can only send FAILED when launchMode is 'Normal'")
-      );
+    const moveOnStatements = Cmi5MoveOnStatements(this, options);
+    const sendOptions = Cmi5MoveOnStatementSendOptions(this, options);
     const newStatementIds: string[] = [];
-    if (effectiveOptions?.score) {
-      const rScore = _toResultScore(effectiveOptions?.score);
-      if (this.launchData.masteryScore) {
-        if (rScore.scaled >= this.launchData.masteryScore) {
-          this.appendStatementIds(
-            await this.pass(rScore, effectiveOptions),
-            newStatementIds
-          );
-        } else {
-          this.appendStatementIds(
-            await this.fail(rScore, effectiveOptions),
-            newStatementIds
-          );
-        }
-      } else {
-        const _setResultScore = (s: Statement): Statement => {
-          return this.setResultScore(rScore, s);
-        };
-        const transformProvided = effectiveOptions?.transform;
-        effectiveOptions = {
-          ...(effectiveOptions || {}),
-          transform:
-            typeof transformProvided === "function"
-              ? // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-                (s) => transformProvided(_setResultScore(s))
-              : // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-                (s) => _setResultScore(s),
-        };
-      }
-    }
-    this.appendStatementIds(
-      await this.complete(effectiveOptions),
-      newStatementIds
-    );
-    if (!options?.disableSendTerminated) {
-      this.appendStatementIds(await this.terminate(), newStatementIds);
+    for (const statement of moveOnStatements) {
+      await this.sendXapiStatement(statement, sendOptions);
+      newStatementIds.push(statement.id);
     }
     return newStatementIds;
   }
@@ -759,87 +494,37 @@ export default class AbstractCmi5 {
     toIds.push.apply(toIds, response.data);
   }
 
-  private async getAuthTokenFromLMS(
-    fetchUrl: string
-  ): Promise<string> {
+  private async getAuthTokenFromLMS(fetchUrl: string): Promise<string> {
     const response = await axios.post<AuthTokenResponse>(fetchUrl);
     return response.data["auth-token"];
   }
 
   private async getLaunchDataFromLMS(): Promise<LaunchData> {
     const launchDataResponse = await (this._xapi.getState({
-      agent: this.launchParameters.actor,
-      activityId: this.launchParameters.activityId,
+      agent: this._launchParameters.actor,
+      activityId: this._launchParameters.activityId,
       stateId: "LMS.LaunchData",
-      registration: this.launchParameters.registration,
+      registration: this._launchParameters.registration,
     }) as AxiosPromise<LaunchData>);
-    return launchDataResponse.data
+    return launchDataResponse.data;
   }
 
   private async getLearnerPreferencesFromLMS(): Promise<LearnerPreferences> {
     try {
       const learnerPrefResponse = await (this._xapi.getAgentProfile({
-        agent: this.launchParameters.actor,
+        agent: this._launchParameters.actor,
         profileId: "cmi5LearnerPreferences",
       }) as AxiosPromise<LearnerPreferences>);
       return learnerPrefResponse.data;
-    } catch(err) {
+    } catch (err) {
       return {};
     }
   }
 
-  private async sendCmi5DefinedStatement(
-    statement: Partial<Statement>,
+  public async sendXapiStatement(
+    mergedStatement: Statement,
     options?: SendStatementOptions
   ): AxiosPromise<string[]> {
-    // 9.4 Object - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#94-object
-    const object: StatementObject = {
-      objectType: "Activity",
-      id: this.launchParameters.activityId,
-    };
-    const context: Context = {
-      contextActivities: {
-        category: [
-          // 9.6.2.1 cmi5 Category Activity - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#9621-cmi5-category-activity
-          Cmi5ContextActivity.CMI5,
-        ],
-      },
-    };
-    const cmi5DefinedStatementRequirements: Partial<Statement> = {
-      object: object,
-      context: context,
-    };
-    const mergedStatement: Partial<Statement> = deepmerge.all([
-      cmi5DefinedStatementRequirements,
-      statement,
-    ]);
-    return this.sendCmi5AllowedStatement(mergedStatement, options);
-  }
-
-  public async sendCmi5AllowedStatement(
-    statement: Partial<Statement>,
-    options?: SendStatementOptions
-  ): AxiosPromise<string[]> {
-    // 9.1 Statement ID - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#statement_id
-    const id = uuidv4();
-    // 9.2 Actor - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#92-actor
-    const actor: Agent = this.launchParameters.actor;
-    // 9.7 Timestamp - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#97-timestamp
-    const timestamp = new Date().toISOString();
-    // 10.0 xAPI State Data Model - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#100-xapi-state-data-model
-    const context: Context = Object.assign({}, this.launchData.contextTemplate);
-    // 9.6.1 Registration - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#961-registration
-    context.registration = this.launchParameters.registration;
-    const cmi5AllowedStatementRequirements: Partial<Statement> = {
-      id: id,
-      actor: actor,
-      timestamp: timestamp,
-      context: context,
-    };
-    const mergedStatement = deepmerge.all([
-      cmi5AllowedStatementRequirements,
-      statement,
-    ]) as Statement;
     const sendStatement =
       options && typeof options.transform === "function"
         ? options.transform(mergedStatement)

--- a/src/AbstractCmi5.ts
+++ b/src/AbstractCmi5.ts
@@ -45,7 +45,10 @@ import {
 
 export * from "./interfaces";
 
-function _applyTransform(mergedStatement: Statement, options: SendStatementOptions) {
+function _applyTransform(
+  mergedStatement: Statement,
+  options: SendStatementOptions
+) {
   return options && typeof options.transform === "function"
     ? options.transform(mergedStatement)
     : mergedStatement;
@@ -186,6 +189,7 @@ export default class AbstractCmi5 {
     return this.sendXapiStatement(statement);
   }
 
+  /* eslint-disable @typescript-eslint/no-unused-vars */
   public interactionTrueFalse(
     testId: string,
     questionId: string,
@@ -197,11 +201,15 @@ export default class AbstractCmi5 {
     duration?: Period,
     objective?: ObjectiveActivity
   ): AxiosPromise<string[]> {
-    // @ts-ignore
+    /* eslint-disable prefer-rest-params */
+    // @ts-expect-error TS doesn't like spreading arguments
     const statement = Cmi5InteractionTrueFalseStatement(this, ...arguments);
+    /* eslint-enable prefer-rest-params */
     return this.sendXapiStatement(statement);
   }
+  /* eslint-enable @typescript-eslint/no-unused-vars */
 
+  /* eslint-disable @typescript-eslint/no-unused-vars */
   public interactionChoice(
     testId: string,
     questionId: string,
@@ -213,12 +221,16 @@ export default class AbstractCmi5 {
     success?: boolean,
     duration?: Period,
     objective?: ObjectiveActivity
+    /* eslint-enable @typescript-eslint/no-unused-vars */
   ): AxiosPromise<string[]> {
-    // @ts-ignore
+    /* eslint-disable prefer-rest-params */
+    // @ts-expect-error TS doesn't like spreading arguments
     const statement = Cmi5InteractionChoiceStatement(this, ...arguments);
+    /* eslint-enable prefer-rest-params */
     return this.sendXapiStatement(statement);
   }
 
+  /* eslint-disable @typescript-eslint/no-unused-vars */
   public interactionFillIn(
     testId: string,
     questionId: string,
@@ -229,12 +241,16 @@ export default class AbstractCmi5 {
     success?: boolean,
     duration?: Period,
     objective?: ObjectiveActivity
+    /* eslint-enable @typescript-eslint/no-unused-vars */
   ): AxiosPromise<string[]> {
-    // @ts-ignore
+    /* eslint-disable prefer-rest-params */
+    // @ts-expect-error TS doesn't like spreading arguments
     const statement = Cmi5InteractionFillInStatement(this, ...arguments);
+    /* eslint-enable prefer-rest-params */
     return this.sendXapiStatement(statement);
   }
 
+  /* eslint-disable @typescript-eslint/no-unused-vars */
   public interactionLongFillIn(
     testId: string,
     questionId: string,
@@ -245,12 +261,16 @@ export default class AbstractCmi5 {
     success?: boolean,
     duration?: Period,
     objective?: ObjectiveActivity
+    /* eslint-enable @typescript-eslint/no-unused-vars */
   ): AxiosPromise<string[]> {
-    // @ts-ignore
+    /* eslint-disable prefer-rest-params */
+    // @ts-expect-error TS doesn't like spreading arguments
     const statement = Cmi5InteractionLongFillInStatement(this, ...arguments);
+    /* eslint-enable prefer-rest-params */
     return this.sendXapiStatement(statement);
   }
 
+  /* eslint-disable @typescript-eslint/no-unused-vars */
   public interactionLikert(
     testId: string,
     questionId: string,
@@ -262,12 +282,16 @@ export default class AbstractCmi5 {
     success?: boolean,
     duration?: Period,
     objective?: ObjectiveActivity
+    /* eslint-enable @typescript-eslint/no-unused-vars */
   ): AxiosPromise<string[]> {
-    // @ts-ignore
+    /* eslint-disable prefer-rest-params */
+    // @ts-expect-error TS doesn't like spreading arguments
     const statement = Cmi5InteractionLikertStatement(this, ...arguments);
+    /* eslint-enable prefer-rest-params */
     return this.sendXapiStatement(statement);
   }
 
+  /* eslint-disable @typescript-eslint/no-unused-vars */
   public interactionMatching(
     testId: string,
     questionId: string,
@@ -280,12 +304,16 @@ export default class AbstractCmi5 {
     success?: boolean,
     duration?: Period,
     objective?: ObjectiveActivity
+    /* eslint-enable @typescript-eslint/no-unused-vars */
   ): AxiosPromise<string[]> {
-    // @ts-ignore
+    /* eslint-disable prefer-rest-params */
+    // @ts-expect-error TS doesn't like spreading arguments
     const statement = Cmi5InteractionMatchingStatement(this, ...arguments);
+    /* eslint-enable prefer-rest-params */
     return this.sendXapiStatement(statement);
   }
 
+  /* eslint-disable @typescript-eslint/no-unused-vars */
   public interactionPerformance(
     testId: string,
     questionId: string,
@@ -297,12 +325,16 @@ export default class AbstractCmi5 {
     success?: boolean,
     duration?: Period,
     objective?: ObjectiveActivity
+    /* eslint-enable @typescript-eslint/no-unused-vars */
   ): AxiosPromise<string[]> {
-    // @ts-ignore
+    /* eslint-disable prefer-rest-params */
+    // @ts-expect-error TS doesn't like spreading arguments
     const statement = Cmi5InteractionPerformanceStatement(this, ...arguments);
+    /* eslint-enable prefer-rest-params */
     return this.sendXapiStatement(statement);
   }
 
+  /* eslint-disable @typescript-eslint/no-unused-vars */
   public interactionSequencing(
     testId: string,
     questionId: string,
@@ -314,12 +346,16 @@ export default class AbstractCmi5 {
     success?: boolean,
     duration?: Period,
     objective?: ObjectiveActivity
+    /* eslint-enable @typescript-eslint/no-unused-vars */
   ): AxiosPromise<string[]> {
-    // @ts-ignore
+    /* eslint-disable prefer-rest-params */
+    // @ts-expect-error TS doesn't like spreading arguments
     const statement = Cmi5InteractionSequencingStatement(this, ...arguments);
+    /* eslint-enable prefer-rest-params */
     return this.sendXapiStatement(statement);
   }
 
+  /* eslint-disable @typescript-eslint/no-unused-vars */
   public interactionNumeric(
     testId: string,
     questionId: string,
@@ -330,12 +366,16 @@ export default class AbstractCmi5 {
     success?: boolean,
     duration?: Period,
     objective?: ObjectiveActivity
+    /* eslint-enable @typescript-eslint/no-unused-vars */
   ): AxiosPromise<string[]> {
-    // @ts-ignore
+    /* eslint-disable prefer-rest-params */
+    // @ts-expect-error TS doesn't like spreading arguments
     const statement = Cmi5InteractionNumericStatement(this, ...arguments);
+    /* eslint-enable prefer-rest-params */
     return this.sendXapiStatement(statement);
   }
 
+  /* eslint-disable @typescript-eslint/no-unused-vars */
   public interactionOther(
     testId: string,
     questionId: string,
@@ -346,12 +386,16 @@ export default class AbstractCmi5 {
     success?: boolean,
     duration?: Period,
     objective?: ObjectiveActivity
+    /* eslint-enable @typescript-eslint/no-unused-vars */
   ): AxiosPromise<string[]> {
-    // @ts-ignore
+    /* eslint-disable prefer-rest-params */
+    // @ts-expect-error TS doesn't like spreading arguments
     const statement = Cmi5InteractionOtherStatement(this, ...arguments);
+    /* eslint-enable prefer-rest-params */
     return this.sendXapiStatement(statement);
   }
 
+  /* eslint-disable @typescript-eslint/no-unused-vars */
   public interaction(
     testId: string,
     questionId: string,
@@ -360,9 +404,12 @@ export default class AbstractCmi5 {
     success?: boolean,
     duration?: Period,
     objective?: ObjectiveActivity
+    /* eslint-enable @typescript-eslint/no-unused-vars */
   ): AxiosPromise<string[]> {
-    // @ts-ignore
+    /* eslint-disable prefer-rest-params */
+    // @ts-expect-error TS doesn't like spreading arguments
     const statement = Cmi5InteractionStatement(this, ...arguments);
+    /* eslint-enable prefer-rest-params */
     return this.sendXapiStatement(statement);
   }
 

--- a/src/AbstractCmi5.ts
+++ b/src/AbstractCmi5.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosPromise, AxiosResponse } from "axios";
+import axios, { AxiosPromise } from "axios";
 import XAPI, {
   InteractionActivityDefinition,
   InteractionComponent,
@@ -12,12 +12,12 @@ import {
   LaunchData,
   LaunchParameters,
   LearnerPreferences,
+  MoveOnOptions,
+  NumericCriteria,
   PassOptions,
   Performance,
   PerformanceCriteria,
   Period,
-  MoveOnOptions,
-  NumericCriteria,
   SendStatementOptions,
 } from "./interfaces";
 import { Cmi5DefinedVerbs } from "./constants";
@@ -44,6 +44,12 @@ import {
 } from "./Cmi5Statements";
 
 export * from "./interfaces";
+
+function _applyTransform(mergedStatement: Statement, options: SendStatementOptions) {
+  return options && typeof options.transform === "function"
+    ? options.transform(mergedStatement)
+    : mergedStatement;
+}
 
 /**
  * Experience API cmi5 Profile (Quartz - 1st Edition)
@@ -191,18 +197,8 @@ export default class AbstractCmi5 {
     duration?: Period,
     objective?: ObjectiveActivity
   ): AxiosPromise<string[]> {
-    const statement = Cmi5InteractionTrueFalseStatement(
-      this,
-      testId,
-      questionId,
-      answer,
-      correctAnswer,
-      name,
-      description,
-      success,
-      duration,
-      objective
-    );
+    // @ts-ignore
+    const statement = Cmi5InteractionTrueFalseStatement(this, ...arguments);
     return this.sendXapiStatement(statement);
   }
 
@@ -218,19 +214,8 @@ export default class AbstractCmi5 {
     duration?: Period,
     objective?: ObjectiveActivity
   ): AxiosPromise<string[]> {
-    const statement = Cmi5InteractionChoiceStatement(
-      this,
-      testId,
-      questionId,
-      answerIds,
-      correctAnswerIds,
-      choices,
-      name,
-      description,
-      success,
-      duration,
-      objective
-    );
+    // @ts-ignore
+    const statement = Cmi5InteractionChoiceStatement(this, ...arguments);
     return this.sendXapiStatement(statement);
   }
 
@@ -245,18 +230,8 @@ export default class AbstractCmi5 {
     duration?: Period,
     objective?: ObjectiveActivity
   ): AxiosPromise<string[]> {
-    const statement = Cmi5InteractionFillInStatement(
-      this,
-      testId,
-      questionId,
-      answers,
-      correctAnswers,
-      name,
-      description,
-      success,
-      duration,
-      objective
-    );
+    // @ts-ignore
+    const statement = Cmi5InteractionFillInStatement(this, ...arguments);
     return this.sendXapiStatement(statement);
   }
 
@@ -271,18 +246,8 @@ export default class AbstractCmi5 {
     duration?: Period,
     objective?: ObjectiveActivity
   ): AxiosPromise<string[]> {
-    const statement = Cmi5InteractionLongFillInStatement(
-      this,
-      testId,
-      questionId,
-      answers,
-      correctAnswers,
-      name,
-      description,
-      success,
-      duration,
-      objective
-    );
+    // @ts-ignore
+    const statement = Cmi5InteractionLongFillInStatement(this, ...arguments);
     return this.sendXapiStatement(statement);
   }
 
@@ -298,19 +263,8 @@ export default class AbstractCmi5 {
     duration?: Period,
     objective?: ObjectiveActivity
   ): AxiosPromise<string[]> {
-    const statement = Cmi5InteractionLikertStatement(
-      this,
-      testId,
-      questionId,
-      answerId,
-      correctAnswerId,
-      scale,
-      name,
-      description,
-      success,
-      duration,
-      objective
-    );
+    // @ts-ignore
+    const statement = Cmi5InteractionLikertStatement(this, ...arguments);
     return this.sendXapiStatement(statement);
   }
 
@@ -327,20 +281,8 @@ export default class AbstractCmi5 {
     duration?: Period,
     objective?: ObjectiveActivity
   ): AxiosPromise<string[]> {
-    const statement = Cmi5InteractionMatchingStatement(
-      this,
-      testId,
-      questionId,
-      answers,
-      correctAnswers,
-      source,
-      target,
-      name,
-      description,
-      success,
-      duration,
-      objective
-    );
+    // @ts-ignore
+    const statement = Cmi5InteractionMatchingStatement(this, ...arguments);
     return this.sendXapiStatement(statement);
   }
 
@@ -356,19 +298,8 @@ export default class AbstractCmi5 {
     duration?: Period,
     objective?: ObjectiveActivity
   ): AxiosPromise<string[]> {
-    const statement = Cmi5InteractionPerformanceStatement(
-      this,
-      testId,
-      questionId,
-      answers,
-      correctAnswers,
-      steps,
-      name,
-      description,
-      success,
-      duration,
-      objective
-    );
+    // @ts-ignore
+    const statement = Cmi5InteractionPerformanceStatement(this, ...arguments);
     return this.sendXapiStatement(statement);
   }
 
@@ -384,19 +315,8 @@ export default class AbstractCmi5 {
     duration?: Period,
     objective?: ObjectiveActivity
   ): AxiosPromise<string[]> {
-    const statement = Cmi5InteractionSequencingStatement(
-      this,
-      testId,
-      questionId,
-      answerIds,
-      correctAnswerIds,
-      choices,
-      name,
-      description,
-      success,
-      duration,
-      objective
-    );
+    // @ts-ignore
+    const statement = Cmi5InteractionSequencingStatement(this, ...arguments);
     return this.sendXapiStatement(statement);
   }
 
@@ -411,18 +331,8 @@ export default class AbstractCmi5 {
     duration?: Period,
     objective?: ObjectiveActivity
   ): AxiosPromise<string[]> {
-    const statement = Cmi5InteractionNumericStatement(
-      this,
-      testId,
-      questionId,
-      answer,
-      correctAnswer,
-      name,
-      description,
-      success,
-      duration,
-      objective
-    );
+    // @ts-ignore
+    const statement = Cmi5InteractionNumericStatement(this, ...arguments);
     return this.sendXapiStatement(statement);
   }
 
@@ -437,19 +347,8 @@ export default class AbstractCmi5 {
     duration?: Period,
     objective?: ObjectiveActivity
   ): AxiosPromise<string[]> {
-    const statement = Cmi5InteractionOtherStatement(
-      this,
-      testId,
-      questionId,
-      answer,
-      correctAnswer,
-      name,
-      description,
-      success,
-      duration,
-      objective
-    );
-
+    // @ts-ignore
+    const statement = Cmi5InteractionOtherStatement(this, ...arguments);
     return this.sendXapiStatement(statement);
   }
 
@@ -462,16 +361,8 @@ export default class AbstractCmi5 {
     duration?: Period,
     objective?: ObjectiveActivity
   ): AxiosPromise<string[]> {
-    const statement = Cmi5InteractionStatement(
-      this,
-      testId,
-      questionId,
-      response,
-      interactionDefinition,
-      success,
-      duration,
-      objective
-    );
+    // @ts-ignore
+    const statement = Cmi5InteractionStatement(this, ...arguments);
     return this.sendXapiStatement(statement);
   }
 
@@ -484,14 +375,6 @@ export default class AbstractCmi5 {
       newStatementIds.push(statement.id);
     }
     return newStatementIds;
-  }
-
-  private appendStatementIds(
-    response: AxiosResponse<string[]>,
-    toIds: string[]
-  ): void {
-    // eslint-disable-next-line prefer-spread
-    toIds.push.apply(toIds, response.data);
   }
 
   private async getAuthTokenFromLMS(fetchUrl: string): Promise<string> {
@@ -522,13 +405,10 @@ export default class AbstractCmi5 {
   }
 
   public async sendXapiStatement(
-    mergedStatement: Statement,
+    statement: Statement,
     options?: SendStatementOptions
   ): AxiosPromise<string[]> {
-    const sendStatement =
-      options && typeof options.transform === "function"
-        ? options.transform(mergedStatement)
-        : mergedStatement;
+    const sendStatement = _applyTransform(statement, options);
     return this._xapi.sendStatement({
       statement: sendStatement,
     });

--- a/src/Cmi5Statements.ts
+++ b/src/Cmi5Statements.ts
@@ -1,24 +1,654 @@
-import XAPI, { InteractionActivityDefinition, ObjectiveActivity, Statement } from "@xapi/xapi";
-import { LaunchParameters, Period } from "./interfaces";
-import { AxiosPromise } from "axios";
+import XAPI, {
+  Agent,
+  Context,
+  InteractionActivityDefinition,
+  InteractionComponent,
+  LanguageMap,
+  ObjectiveActivity,
+  ResultScore,
+  Statement,
+  StatementObject,
+} from "@xapi/xapi";
+import { v4 as uuidv4 } from "uuid";
+import { default as deepmerge } from "deepmerge";
+import {
+  LaunchContext,
+  MoveOnOptions,
+  NumericCriteria,
+  NumericExact,
+  NumericRange,
+  PassOptions,
+  Performance,
+  PerformanceCriteria,
+  Period,
+  SendStatementOptions,
+  StatementTransform,
+} from "./interfaces";
+import { Cmi5ContextActivity, Cmi5DefinedVerbs } from "./constants";
 
-export function Cmi5ProgressStatement(launchParameters: LaunchParameters, percent: number): Statement {
-  return {
+export function Cmi5DefinedStatement(
+  ctx: LaunchContext,
+  statement: Partial<Statement>
+): Statement {
+  // 9.4 Object - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#94-object
+  const object: StatementObject = {
+    objectType: "Activity",
+    id: ctx.launchParameters.activityId,
+  };
+  const context: Context = {
+    contextActivities: {
+      category: [
+        // 9.6.2.1 cmi5 Category Activity - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#9621-cmi5-category-activity
+        Cmi5ContextActivity.CMI5,
+      ],
+    },
+  };
+  const cmi5DefinedStatementRequirements: Partial<Statement> = {
+    object: object,
+    context: context,
+  };
+
+  return Cmi5AllowedStatement(
+    ctx,
+    deepmerge.all([cmi5DefinedStatementRequirements, statement])
+  );
+}
+
+export function Cmi5AllowedStatement(
+  ctx: LaunchContext,
+  statement: Partial<Statement>
+): Statement {
+  // 9.1 Statement ID - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#statement_id
+  const id = uuidv4();
+  // 9.2 Actor - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#92-actor
+  const actor: Agent = ctx.launchParameters.actor;
+  // 9.7 Timestamp - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#97-timestamp
+  const timestamp = new Date().toISOString();
+  // 10.0 xAPI State Data Model - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#100-xapi-state-data-model
+  const context: Context = Object.assign({}, ctx.launchData.contextTemplate);
+  // 9.6.1 Registration - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#961-registration
+  context.registration = ctx.launchParameters.registration;
+  const cmi5AllowedStatementRequirements: Partial<Statement> = {
+    id: id,
+    actor: actor,
+    timestamp: timestamp,
+    context: context,
+  };
+
+  return deepmerge.all([
+    cmi5AllowedStatementRequirements,
+    statement,
+  ]) as Statement;
+}
+
+export function Cmi5CompleteStatement(
+  ctx: LaunchContext,
+  options?: SendStatementOptions
+): Statement {
+  // 10.0 xAPI State Data Model - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#100-xapi-state-data-model
+  if (ctx.launchData.launchMode !== "Normal")
+    throw new Error("Can only send COMPLETED when launchMode is 'Normal'");
+  return Cmi5DefinedStatement(ctx, {
+    // 9.3.3 Completed - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#933-completed
+    verb: Cmi5DefinedVerbs.COMPLETED,
+    result: {
+      // 9.5.3 Completion - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#953-completion
+      completion: true,
+      // 9.5.4.1 Duration - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#completed-statement
+      duration: XAPI.calculateISO8601Duration(ctx.initializedDate, new Date()),
+    },
+    context: {
+      contextActivities: {
+        category: [
+          // 9.6.2.2 moveOn Category Activity - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#9622-moveon-category-activity
+          Cmi5ContextActivity.MOVE_ON,
+        ],
+      },
+    },
+  });
+}
+
+export function Cmi5PassStatement(
+  ctx: LaunchContext,
+  score?: ResultScore | number,
+  objectiveOrOptions?: ObjectiveActivity | PassOptions
+): Statement {
+  // 10.0 xAPI State Data Model - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#100-xapi-state-data-model
+  if (ctx.launchData.launchMode !== "Normal")
+    throw new Error("Can only send PASSED when launchMode is 'Normal'");
+  const rScore = _toResultScore(score);
+  // Best Practice #4 - AU Mastery Score - https://aicc.github.io/CMI-5_Spec_Current/best_practices/
+  if (
+    ctx.launchData.masteryScore &&
+    (!rScore ||
+      isNaN(Number(rScore.scaled)) ||
+      rScore.scaled < ctx.launchData.masteryScore)
+  )
+    throw new Error("Learner has not met Mastery Score");
+  const objective = _isObjectiveActivity(objectiveOrOptions)
+    ? objectiveOrOptions
+    : objectiveOrOptions?.objectiveActivity;
+  return Cmi5DefinedStatement(ctx, {
+    // 9.3.4 Passed - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#934-passed
+    verb: Cmi5DefinedVerbs.PASSED,
+    result: {
+      // 9.5.1 Score - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#951-score
+      ...(rScore ? { score: rScore } : {}),
+      // 9.5.2 Success - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#952-success
+      success: true,
+      // 9.5.4.1 Duration - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#passed-statement
+      duration: XAPI.calculateISO8601Duration(ctx.initializedDate, new Date()),
+    },
+    context: {
+      contextActivities: {
+        // 9.6.2.2 moveOn Category Activity - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#9622-moveon-category-activity
+        category: [Cmi5ContextActivity.MOVE_ON],
+        // Best Practice #1 - Use of Objectives - https://aicc.github.io/CMI-5_Spec_Current/best_practices/
+        ...(objective ? { parent: [objective] } : {}),
+      },
+      ...(ctx.launchData.masteryScore
+        ? {
+            extensions: {
+              "https://w3id.org/xapi/cmi5/context/extensions/masteryscore":
+                ctx.launchData.masteryScore,
+            },
+          }
+        : {}),
+    },
+  });
+}
+
+export function Cmi5FailStatement(
+  ctx: LaunchContext,
+  score?: ResultScore | number,
+): Statement {
+  // 10.0 xAPI State Data Model - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#100-xapi-state-data-model
+  if (ctx.launchData.launchMode !== "Normal")
+    throw new Error("Can only send FAILED when launchMode is 'Normal'");
+  const rScore = _toResultScore(score);
+
+  return Cmi5DefinedStatement(ctx, {
+    // 9.3.5 Failed - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#935-failed
+    verb: Cmi5DefinedVerbs.FAILED,
+    result: {
+      // 9.5.1 Score - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#951-score
+      ...(rScore ? { score: rScore } : {}),
+      // 9.5.2 Success - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#952-success
+      success: false,
+      // 9.5.4.1 Duration - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#failed-statement
+      duration: XAPI.calculateISO8601Duration(ctx.initializedDate, new Date()),
+    },
+    context: {
+      contextActivities: {
+        category: [
+          // 9.6.2.2 moveOn Category Activity - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#9622-moveon-category-activity
+          Cmi5ContextActivity.MOVE_ON,
+        ],
+      },
+      ...(ctx.launchData.masteryScore
+        ? {
+            extensions: {
+              "https://w3id.org/xapi/cmi5/context/extensions/masteryscore":
+                ctx.launchData.masteryScore,
+            },
+          }
+        : {}),
+    },
+  });
+}
+
+export function Cmi5TerminateStatement(ctx: LaunchContext): Statement {
+  return Cmi5DefinedStatement(ctx, {
+    // 9.3.8 Terminated - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#938-terminated
+    verb: Cmi5DefinedVerbs.TERMINATED,
+    result: {
+      // 9.5.4.1 Duration - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#terminated-statement
+      duration: XAPI.calculateISO8601Duration(ctx.initializedDate, new Date()),
+    },
+  });
+}
+
+// "cmi5 allowed" Statements
+export function Cmi5ProgressStatement(
+  ctx: LaunchContext,
+  percent: number
+): Statement {
+  return Cmi5AllowedStatement(ctx, {
     verb: XAPI.Verbs.PROGRESSED,
     object: {
       objectType: "Activity",
-      id: launchParameters.activityId,
+      id: ctx.launchParameters.activityId,
     },
     result: {
       extensions: {
         "https://w3id.org/xapi/cmi5/result/extensions/progress": percent,
       },
     },
+  });
+}
+
+function setResultScore(resultScore: ResultScore, s: Statement): Statement {
+  return {
+    ...s,
+    result: {
+      ...(s.result || {}),
+      score: resultScore,
+    },
+  };
+}
+
+export function Cmi5MoveOnStatementSendOptions(
+  ctx: LaunchContext,
+  options?: MoveOnOptions
+): MoveOnOptions {
+  if (options?.score && !ctx.launchData.masteryScore) {
+    const rScore = _toResultScore(options?.score);
+    const _setResultScore: StatementTransform = (s) =>
+      setResultScore(rScore, s);
+    const transformProvided = options?.transform;
+    const transform =
+      typeof transformProvided === "function"
+        ? (s) => transformProvided(_setResultScore(s))
+        : (s) => _setResultScore(s);
+    return { ...options, transform };
   }
+  return options || {};
+}
+
+export function Cmi5MoveOnStatements(
+  ctx: LaunchContext,
+  options?: MoveOnOptions
+): Statement[] {
+  const statements: Statement[] = [];
+  // 10.0 xAPI State Data Model - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#100-xapi-state-data-model
+  if (ctx.launchData.launchMode !== "Normal") {
+    throw new Error("Can only send FAILED when launchMode is 'Normal'");
+  }
+
+  if (options?.score) {
+    const rScore = _toResultScore(options?.score);
+    if (ctx.launchData.masteryScore) {
+      if (rScore.scaled >= ctx.launchData.masteryScore) {
+        statements.push(Cmi5PassStatement(ctx, rScore, options));
+      } else {
+        statements.push(Cmi5FailStatement(ctx, rScore));
+      }
+    }
+  }
+
+  statements.push(Cmi5CompleteStatement(ctx));
+  if (!options?.disableSendTerminated) {
+    statements.push(Cmi5TerminateStatement(ctx));
+  }
+
+  return statements;
+}
+
+export function Cmi5InteractionTrueFalseStatement(
+  ctx: LaunchContext,
+  testId: string,
+  questionId: string,
+  answer: boolean,
+  correctAnswer?: boolean,
+  name?: LanguageMap,
+  description?: LanguageMap,
+  success?: boolean,
+  duration?: Period,
+  objective?: ObjectiveActivity
+): Statement {
+  return Cmi5InteractionStatement(
+    ctx,
+    testId,
+    questionId,
+    answer.toString(),
+    {
+      type: "http://adlnet.gov/expapi/activities/cmi.interaction",
+      interactionType: "true-false",
+      ...(correctAnswer !== undefined
+        ? {
+            correctResponsesPattern: correctAnswer ? ["true"] : ["false"],
+          }
+        : {}),
+      ...(name ? { name } : {}),
+      ...(description ? { description } : {}),
+    },
+    success,
+    duration,
+    objective
+  );
+}
+
+export function Cmi5InteractionChoiceStatement(
+  ctx: LaunchContext,
+  testId: string,
+  questionId: string,
+  answerIds: string[],
+  correctAnswerIds?: string[],
+  choices?: InteractionComponent[],
+  name?: LanguageMap,
+  description?: LanguageMap,
+  success?: boolean,
+  duration?: Period,
+  objective?: ObjectiveActivity
+): Statement {
+  return Cmi5InteractionStatement(
+    ctx,
+    testId,
+    questionId,
+    answerIds.join("[,]"),
+    {
+      type: "http://adlnet.gov/expapi/activities/cmi.interaction",
+      interactionType: "choice",
+      ...(correctAnswerIds
+        ? {
+            correctResponsesPattern: [correctAnswerIds.join("[,]")],
+          }
+        : {}),
+      ...(choices ? { choices } : {}),
+      ...(name ? { name } : {}),
+      ...(description ? { description } : {}),
+    },
+    success,
+    duration,
+    objective
+  );
+}
+
+export function Cmi5InteractionFillInStatement(
+  ctx: LaunchContext,
+  testId: string,
+  questionId: string,
+  answers: string[],
+  correctAnswers?: string[],
+  name?: LanguageMap,
+  description?: LanguageMap,
+  success?: boolean,
+  duration?: Period,
+  objective?: ObjectiveActivity
+): Statement {
+  return Cmi5InteractionStatement(
+    ctx,
+    testId,
+    questionId,
+    answers.join("[,]"),
+    {
+      type: "http://adlnet.gov/expapi/activities/cmi.interaction",
+      interactionType: "fill-in",
+      ...(correctAnswers
+        ? {
+            correctResponsesPattern: [correctAnswers.join("[,]")],
+          }
+        : {}),
+      ...(name ? { name } : {}),
+      ...(description ? { description } : {}),
+    },
+    success,
+    duration,
+    objective
+  );
+}
+
+export function Cmi5InteractionLongFillInStatement(
+  ctx: LaunchContext,
+  testId: string,
+  questionId: string,
+  answers: string[],
+  correctAnswers?: string[],
+  name?: LanguageMap,
+  description?: LanguageMap,
+  success?: boolean,
+  duration?: Period,
+  objective?: ObjectiveActivity
+): Statement {
+  return Cmi5InteractionStatement(
+    ctx,
+    testId,
+    questionId,
+    answers.join("[,]"),
+    {
+      type: "http://adlnet.gov/expapi/activities/cmi.interaction",
+      interactionType: "long-fill-in",
+      ...(correctAnswers
+        ? {
+            correctResponsesPattern: [correctAnswers.join("[,]")],
+          }
+        : {}),
+      ...(name ? { name } : {}),
+      ...(description ? { description } : {}),
+    },
+    success,
+    duration,
+    objective
+  );
+}
+
+export function Cmi5InteractionLikertStatement(
+  ctx: LaunchContext,
+  testId: string,
+  questionId: string,
+  answerId: string,
+  correctAnswerId?: string,
+  scale?: InteractionComponent[],
+  name?: LanguageMap,
+  description?: LanguageMap,
+  success?: boolean,
+  duration?: Period,
+  objective?: ObjectiveActivity
+): Statement {
+  return Cmi5InteractionStatement(
+    ctx,
+    testId,
+    questionId,
+    answerId,
+    {
+      type: "http://adlnet.gov/expapi/activities/cmi.interaction",
+      interactionType: "likert",
+      ...(correctAnswerId
+        ? {
+            correctResponsesPattern: [correctAnswerId],
+          }
+        : {}),
+      ...(scale ? { scale } : {}),
+      ...(name ? { name } : {}),
+      ...(description ? { description } : {}),
+    },
+    success,
+    duration,
+    objective
+  );
+}
+
+export function Cmi5InteractionMatchingStatement(
+  ctx: LaunchContext,
+  testId: string,
+  questionId: string,
+  answers: { [sourceId: string]: string },
+  correctAnswers?: { [sourceId: string]: string },
+  source?: InteractionComponent[],
+  target?: InteractionComponent[],
+  name?: LanguageMap,
+  description?: LanguageMap,
+  success?: boolean,
+  duration?: Period,
+  objective?: ObjectiveActivity
+): Statement {
+  return Cmi5InteractionStatement(
+    ctx,
+    testId,
+    questionId,
+    Object.entries(answers)
+      .map(([k, v]) => `${k}[.]${v}`)
+      .join("[,]"),
+    {
+      type: "http://adlnet.gov/expapi/activities/cmi.interaction",
+      interactionType: "matching",
+      ...(correctAnswers
+        ? {
+            correctResponsesPattern: [
+              Object.entries(correctAnswers)
+                .map(([key, val]) => `${key}[.]${val}`)
+                .join("[,]"),
+            ],
+          }
+        : {}),
+      ...(source ? { source } : {}),
+      ...(target ? { target } : {}),
+      ...(name ? { name } : {}),
+      ...(description ? { description } : {}),
+    },
+    success,
+    duration,
+    objective
+  );
+}
+
+export function Cmi5InteractionPerformanceStatement(
+  ctx: LaunchContext,
+  testId: string,
+  questionId: string,
+  answers: Performance,
+  correctAnswers?: PerformanceCriteria[],
+  steps?: InteractionComponent[],
+  name?: LanguageMap,
+  description?: LanguageMap,
+  success?: boolean,
+  duration?: Period,
+  objective?: ObjectiveActivity
+): Statement {
+  return Cmi5InteractionStatement(
+    ctx,
+    testId,
+    questionId,
+    Object.entries(answers)
+      .map(([k, v]) => `${k}[.]${v}`)
+      .join("[,]"),
+    {
+      type: "http://adlnet.gov/expapi/activities/cmi.interaction",
+      interactionType: "performance",
+      ...(correctAnswers
+        ? {
+            correctResponsesPattern: [
+              Object.entries(correctAnswers)
+                .map(([k, v]) => `${k}[.]${_numericCriteriaToString(v)}`)
+                .join("[,]"),
+            ],
+          }
+        : {}),
+      ...(steps ? { steps } : {}),
+      ...(name ? { name } : {}),
+      ...(description ? { description } : {}),
+    },
+    success,
+    duration,
+    objective
+  );
+}
+
+export function Cmi5InteractionSequencingStatement(
+  ctx: LaunchContext,
+  testId: string,
+  questionId: string,
+  answerIds: string[],
+  correctAnswerIds: string[],
+  choices?: InteractionComponent[],
+  name?: LanguageMap,
+  description?: LanguageMap,
+  success?: boolean,
+  duration?: Period,
+  objective?: ObjectiveActivity
+): Statement {
+  return Cmi5InteractionStatement(
+    ctx,
+    testId,
+    questionId,
+    answerIds.join("[,]"),
+    {
+      type: "http://adlnet.gov/expapi/activities/cmi.interaction",
+      interactionType: "sequencing",
+      ...(correctAnswerIds
+        ? {
+            correctResponsesPattern: [correctAnswerIds.join("[,]")],
+          }
+        : {}),
+      ...(choices ? { choices } : {}),
+      ...(name ? { name } : {}),
+      ...(description ? { description } : {}),
+    },
+    success,
+    duration,
+    objective
+  );
+}
+
+export function Cmi5InteractionNumericStatement(
+  ctx: LaunchContext,
+  testId: string,
+  questionId: string,
+  answer: number,
+  correctAnswer: NumericCriteria,
+  name?: LanguageMap,
+  description?: LanguageMap,
+  success?: boolean,
+  duration?: Period,
+  objective?: ObjectiveActivity
+): Statement {
+  const correctAnswerObj = correctAnswer
+    ? { correctResponsesPattern: [_numericCriteriaToString(correctAnswer)] }
+    : {};
+  return Cmi5InteractionStatement(
+    ctx,
+    testId,
+    questionId,
+    answer.toString(),
+    {
+      type: "http://adlnet.gov/expapi/activities/cmi.interaction",
+      interactionType: "numeric",
+      ...correctAnswerObj,
+      ...(name ? { name } : {}),
+      ...(description ? { description } : {}),
+    },
+    success,
+    duration,
+    objective
+  );
+}
+
+export function Cmi5InteractionOtherStatement(
+  ctx: LaunchContext,
+  testId: string,
+  questionId: string,
+  answer: string,
+  correctAnswer: string,
+  name?: LanguageMap,
+  description?: LanguageMap,
+  success?: boolean,
+  duration?: Period,
+  objective?: ObjectiveActivity
+): Statement {
+  return Cmi5InteractionStatement(
+    ctx,
+    testId,
+    questionId,
+    answer,
+    {
+      type: "http://adlnet.gov/expapi/activities/cmi.interaction",
+      interactionType: "other",
+      ...(correctAnswer
+        ? {
+            correctResponsesPattern: [correctAnswer],
+          }
+        : {}),
+      ...(name ? { name } : {}),
+      ...(description ? { description } : {}),
+    },
+    success,
+    duration,
+    objective
+  );
 }
 
 export function Cmi5InteractionStatement(
-  launchParameters: LaunchParameters,
+  ctx: LaunchContext,
   testId: string,
   questionId: string,
   response: string,
@@ -27,35 +657,77 @@ export function Cmi5InteractionStatement(
   duration?: Period,
   objective?: ObjectiveActivity
 ): Statement {
-  return {
+  return Cmi5AllowedStatement(ctx, {
     verb: XAPI.Verbs.ANSWERED,
     result: {
       response: response,
       ...(duration
         ? {
-          duration: XAPI.calculateISO8601Duration(
-            duration.start,
-            duration.end
-          ),
-        }
+            duration: XAPI.calculateISO8601Duration(
+              duration.start,
+              duration.end
+            ),
+          }
         : {}),
       ...(typeof success === "boolean" ? { success } : {}),
     },
     object: {
       objectType: "Activity",
       // Best Practice #16 - AU should use a derived activity ID for “cmi.interaction” statements - https://aicc.github.io/CMI-5_Spec_Current/best_practices/
-      id: `${launchParameters.activityId}/test/${testId}/question/${questionId}`,
+      id: `${ctx.launchParameters.activityId}/test/${testId}/question/${questionId}`,
       definition: interactionDefinition,
     },
     // Best Practice #1 - Use of Objectives - https://aicc.github.io/CMI-5_Spec_Current/best_practices/
     ...(objective
       ? {
-        context: {
-          contextActivities: {
-            parent: [objective],
+          context: {
+            contextActivities: {
+              parent: [objective],
+            },
           },
-        },
-      }
+        }
       : {}),
-  };
+  });
+}
+
+// Helper/utility functions
+
+function _isObjectiveActivity(x?: unknown): x is ObjectiveActivity {
+  return (
+    x &&
+    x.objectType === "Activity" &&
+    typeof x.id === "string" &&
+    x.definition.type === "http://adlnet.gov/expapi/activities/objective"
+  );
+}
+
+function _toResultScore(s?: ResultScore | number): ResultScore | undefined {
+  return _isNumber(s) ? { scaled: Number(s) } : s;
+}
+
+function _isNumber(n?: number | unknown): n is number {
+  return !isNaN(Number(n));
+}
+
+function _isNumericExact(candidate: unknown): candidate is NumericExact {
+  return typeof candidate === "object" && "exact" in candidate;
+}
+
+function _isNumericRange(candidate: unknown): candidate is NumericRange {
+  return (
+    typeof candidate === "object" && "min" in candidate && "max" in candidate
+  );
+}
+
+function _numericCriteriaToString(
+  criteria: NumericExact | NumericRange | unknown
+) {
+  if (_isNumericExact(criteria)) {
+    return String(criteria.exact);
+  } else if (_isNumericRange(criteria)) {
+    const { min, max } = criteria;
+    return `${min}:${max}`;
+  } else {
+    return ":";
+  }
 }

--- a/src/Cmi5Statements.ts
+++ b/src/Cmi5Statements.ts
@@ -21,15 +21,16 @@ import {
   Performance,
   PerformanceCriteria,
   Period,
-  SendStatementOptions,
   StatementTransform,
 } from "./interfaces";
 import {
   Cmi5ContextActivity,
-  Cmi5DefinedVerbs, Cmi5Extension, Cmi5InteractionIRI,
+  Cmi5DefinedVerbs,
+  Cmi5ContextExtension,
+  Cmi5InteractionIRI,
   Cmi5InteractionType,
+  Cmi5ResultExtension,
 } from "./constants";
-
 
 export function Cmi5DefinedStatement(
   ctx: LaunchContext,
@@ -116,7 +117,7 @@ export function Cmi5PassStatement(
   score?: ResultScore | number,
   objectiveOrOptions?: ObjectiveActivity | PassOptions
 ): Statement {
-  const masteryScore = ctx.launchData.masteryScore
+  const masteryScore = ctx.launchData.masteryScore;
   // 10.0 xAPI State Data Model - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#100-xapi-state-data-model
   if (ctx.launchData.launchMode !== "Normal")
     throw new Error("Can only send PASSED when launchMode is 'Normal'");
@@ -148,7 +149,7 @@ export function Cmi5PassStatement(
         ...(objective ? { parent: [objective] } : {}),
       },
       ...(masteryScore
-        ? { extensions: { [Cmi5Extension.MASTERY_SCORE]: masteryScore } }
+        ? { extensions: { [Cmi5ContextExtension.MASTERY_SCORE]: masteryScore } }
         : {}),
     },
   });
@@ -156,7 +157,7 @@ export function Cmi5PassStatement(
 
 export function Cmi5FailStatement(
   ctx: LaunchContext,
-  score?: ResultScore | number,
+  score?: ResultScore | number
 ): Statement {
   // 10.0 xAPI State Data Model - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#100-xapi-state-data-model
   if (ctx.launchData.launchMode !== "Normal")
@@ -182,8 +183,7 @@ export function Cmi5FailStatement(
       ...(ctx.launchData.masteryScore
         ? {
             extensions: {
-              [Cmi5Extension.MASTERY_SCORE]:
-                ctx.launchData.masteryScore,
+              [Cmi5ContextExtension.MASTERY_SCORE]: ctx.launchData.masteryScore,
             },
           }
         : {}),
@@ -215,7 +215,7 @@ export function Cmi5ProgressStatement(
     },
     result: {
       extensions: {
-        [Cmi5Extension.PROGRESS]: percent,
+        [Cmi5ResultExtension.PROGRESS]: percent,
       },
     },
   });
@@ -615,9 +615,7 @@ export function Cmi5InteractionOtherStatement(
     {
       type: Cmi5InteractionIRI,
       interactionType: "other",
-      ...(correctAnswer
-        ? { correctResponsesPattern: [correctAnswer] }
-        : {}),
+      ...(correctAnswer ? { correctResponsesPattern: [correctAnswer] } : {}),
       ...(name ? { name } : {}),
       ...(description ? { description } : {}),
     },
@@ -663,7 +661,6 @@ export function Cmi5InteractionStatement(
   });
 }
 
-
 // Helper/utility functions
 
 // Formatting
@@ -687,10 +684,6 @@ function _numericCriteriaToString(
 
 function _durationFromPeriod(period: Period) {
   return XAPI.calculateISO8601Duration(period.start, period.end);
-}
-
-function _durationFromNow(then: Date) {
-  return XAPI.calculateISO8601Duration(then, new Date());
 }
 
 // Type predicates
@@ -724,8 +717,9 @@ function _isNumericRange(candidate: unknown): candidate is NumericRange {
   );
 }
 
-function _didMeetMasteryScore(masteryScore: number, rScore?: ResultScore): boolean {
-  return rScore &&
-    _isNumber(rScore.scaled) &&
-    rScore.scaled >= masteryScore;
+function _didMeetMasteryScore(
+  masteryScore: number,
+  rScore?: ResultScore
+): boolean {
+  return rScore && _isNumber(rScore.scaled) && rScore.scaled >= masteryScore;
 }

--- a/src/Cmi5Statements.ts
+++ b/src/Cmi5Statements.ts
@@ -1,0 +1,61 @@
+import XAPI, { InteractionActivityDefinition, ObjectiveActivity, Statement } from "@xapi/xapi";
+import { LaunchParameters, Period } from "./interfaces";
+import { AxiosPromise } from "axios";
+
+export function Cmi5ProgressStatement(launchParameters: LaunchParameters, percent: number): Statement {
+  return {
+    verb: XAPI.Verbs.PROGRESSED,
+    object: {
+      objectType: "Activity",
+      id: launchParameters.activityId,
+    },
+    result: {
+      extensions: {
+        "https://w3id.org/xapi/cmi5/result/extensions/progress": percent,
+      },
+    },
+  }
+}
+
+export function Cmi5InteractionStatement(
+  launchParameters: LaunchParameters,
+  testId: string,
+  questionId: string,
+  response: string,
+  interactionDefinition: InteractionActivityDefinition,
+  success?: boolean,
+  duration?: Period,
+  objective?: ObjectiveActivity
+): Statement {
+  return {
+    verb: XAPI.Verbs.ANSWERED,
+    result: {
+      response: response,
+      ...(duration
+        ? {
+          duration: XAPI.calculateISO8601Duration(
+            duration.start,
+            duration.end
+          ),
+        }
+        : {}),
+      ...(typeof success === "boolean" ? { success } : {}),
+    },
+    object: {
+      objectType: "Activity",
+      // Best Practice #16 - AU should use a derived activity ID for “cmi.interaction” statements - https://aicc.github.io/CMI-5_Spec_Current/best_practices/
+      id: `${launchParameters.activityId}/test/${testId}/question/${questionId}`,
+      definition: interactionDefinition,
+    },
+    // Best Practice #1 - Use of Objectives - https://aicc.github.io/CMI-5_Spec_Current/best_practices/
+    ...(objective
+      ? {
+        context: {
+          contextActivities: {
+            parent: [objective],
+          },
+        },
+      }
+      : {}),
+  };
+}

--- a/src/constants/Cmi5ContextExtension.ts
+++ b/src/constants/Cmi5ContextExtension.ts
@@ -1,0 +1,4 @@
+export class Cmi5ContextExtension {
+  public static readonly MASTERY_SCORE =
+    "https://w3id.org/xapi/cmi5/context/extensions/masteryscore";
+}

--- a/src/constants/Cmi5Extension.ts
+++ b/src/constants/Cmi5Extension.ts
@@ -1,5 +1,0 @@
-// 9.3 Verbs - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#93-verbs
-export class Cmi5Extension {
-  public static readonly MASTERY_SCORE = "https://w3id.org/xapi/cmi5/context/extensions/masteryscore";
-  public static readonly PROGRESS = "https://w3id.org/xapi/cmi5/result/extensions/progress";
-}

--- a/src/constants/Cmi5Extension.ts
+++ b/src/constants/Cmi5Extension.ts
@@ -1,0 +1,5 @@
+// 9.3 Verbs - https://github.com/AICC/CMI-5_Spec_Current/blob/quartz/cmi5_spec.md#93-verbs
+export class Cmi5Extension {
+  public static readonly MASTERY_SCORE = "https://w3id.org/xapi/cmi5/context/extensions/masteryscore";
+  public static readonly PROGRESS = "https://w3id.org/xapi/cmi5/result/extensions/progress";
+}

--- a/src/constants/Cmi5InteractionType.ts
+++ b/src/constants/Cmi5InteractionType.ts
@@ -1,4 +1,5 @@
-export const Cmi5InteractionIRI = "http://adlnet.gov/expapi/activities/cmi.interaction" as const;
+export const Cmi5InteractionIRI =
+  "http://adlnet.gov/expapi/activities/cmi.interaction" as const;
 
 export class Cmi5InteractionType {
   public static readonly TRUE_FALSE = "true-false";

--- a/src/constants/Cmi5InteractionType.ts
+++ b/src/constants/Cmi5InteractionType.ts
@@ -1,0 +1,13 @@
+export const Cmi5InteractionIRI = "http://adlnet.gov/expapi/activities/cmi.interaction" as const;
+
+export class Cmi5InteractionType {
+  public static readonly TRUE_FALSE = "true-false";
+  public static readonly CHOICE = "choice";
+  public static readonly FILL_IN = "fill-in";
+  public static readonly LONG_FILL_IN = "long-fill-in";
+  public static readonly PERFORMANCE = "performance";
+  public static readonly NUMERIC = "numeric";
+  public static readonly SEQUENCING = "sequencing";
+  public static readonly MATCHING = "matching";
+  public static readonly LIKERT = "likert";
+}

--- a/src/constants/Cmi5ResultExtension.ts
+++ b/src/constants/Cmi5ResultExtension.ts
@@ -1,0 +1,4 @@
+export class Cmi5ResultExtension {
+  public static readonly PROGRESS =
+    "https://w3id.org/xapi/cmi5/result/extensions/progress";
+}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,5 @@
 export * from "./Cmi5ContextActivity";
+export * from "./Cmi5ContextExtension";
 export * from "./Cmi5DefinedVerbs";
-export * from "./Cmi5Extension";
 export * from "./Cmi5InteractionType";
+export * from "./Cmi5ResultExtension";

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,2 +1,4 @@
 export * from "./Cmi5ContextActivity";
 export * from "./Cmi5DefinedVerbs";
+export * from "./Cmi5Extension";
+export * from "./Cmi5InteractionType";

--- a/src/interfaces/LaunchContext.ts
+++ b/src/interfaces/LaunchContext.ts
@@ -1,0 +1,8 @@
+import { LaunchParameters } from "interfaces/LaunchParameters";
+import { LaunchData } from "interfaces/LaunchData";
+
+export interface LaunchContext {
+  initializedDate: Date;
+  launchParameters: LaunchParameters;
+  launchData: LaunchData;
+}

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,4 +1,5 @@
 export * from "./AuthTokenResponse";
+export * from "./LaunchContext";
 export * from "./LaunchData";
 export * from "./LaunchParameters";
 export * from "./LearnerPreferences";

--- a/test/__tests__/cmi5-statements.spec.ts
+++ b/test/__tests__/cmi5-statements.spec.ts
@@ -1,9 +1,14 @@
-import { LaunchContext, LaunchData, LaunchParameters } from "../../src/interfaces";
-import { beforeEach } from "node:test";
+import {
+  LaunchContext,
+  LaunchData,
+  LaunchParameters,
+} from "../../src/interfaces";
 import { randomUUID } from "node:crypto";
-import Cmi5 from "../../src/Cmi5";
 import { Cmi5DefinedVerbs } from "../../src/constants";
-import { Cmi5CompleteStatement, Cmi5PassStatement } from "../../src/Cmi5Statements";
+import {
+  Cmi5CompleteStatement,
+  Cmi5PassStatement,
+} from "../../src/Cmi5Statements";
 import { ResultScore } from "@xapi/xapi";
 
 describe("Cmi5 Statements", () => {
@@ -13,17 +18,17 @@ describe("Cmi5 Statements", () => {
     endpoint: "http://fake-lrs.example.com",
     fetch: "http://fake-fetch.lms.example.com",
     registration: randomUUID(),
-  }
+  };
   const DEFAULT_LAUNCH_DATA: LaunchData = {
     contextTemplate: {},
     launchMode: "Normal",
     moveOn: "CompletedAndPassed",
-  }
+  };
   const DEFAULT_LAUNCH_CONTEXT: LaunchContext = {
     initializedDate: new Date(),
     launchParameters: DEFAULT_LAUNCH_PARAMETERS,
     launchData: DEFAULT_LAUNCH_DATA,
-  }
+  };
 
   describe("Cmi5CompleteStatement", () => {
     [
@@ -33,28 +38,32 @@ describe("Cmi5 Statements", () => {
       it(`calculates duration as time since initialized (${ex.seconds}s=${ex.expectedDuration})`, () => {
         const ctx: LaunchContext = {
           ...DEFAULT_LAUNCH_CONTEXT,
-          initializedDate: new Date(Date.now() - (ex.seconds * 1000)),
-        }
+          initializedDate: new Date(Date.now() - ex.seconds * 1000),
+        };
         const statement = Cmi5CompleteStatement(ctx);
         expect(statement.verb).toEqual(Cmi5DefinedVerbs.COMPLETED);
         expect(statement.result.duration).toEqual(ex.expectedDuration);
       });
     });
 
-    ["Browse", "Review", null].forEach((launchMode: LaunchData["launchMode"]) => {
-      it(`throws exception if launchMode is '${launchMode}'`, async () => {
-        const ctx: LaunchContext = {
-          ...DEFAULT_LAUNCH_CONTEXT,
-          launchData: {
-            ...DEFAULT_LAUNCH_DATA,
-            launchMode: launchMode,
-          },
-        }
-        expect(() => Cmi5CompleteStatement(ctx)).toThrow(expect.objectContaining({
-          message: "Can only send COMPLETED when launchMode is 'Normal'",
-        }));
-      });
-    });
+    ["Browse", "Review", null].forEach(
+      (launchMode: LaunchData["launchMode"]) => {
+        it(`throws exception if launchMode is '${launchMode}'`, async () => {
+          const ctx: LaunchContext = {
+            ...DEFAULT_LAUNCH_CONTEXT,
+            launchData: {
+              ...DEFAULT_LAUNCH_DATA,
+              launchMode: launchMode,
+            },
+          };
+          expect(() => Cmi5CompleteStatement(ctx)).toThrow(
+            expect.objectContaining({
+              message: "Can only send COMPLETED when launchMode is 'Normal'",
+            })
+          );
+        });
+      }
+    );
   });
 
   describe("Cmi5PassStatement", () => {
@@ -78,14 +87,16 @@ describe("Cmi5 Statements", () => {
           launchData: {
             ...DEFAULT_LAUNCH_DATA,
             masteryScore: 0.5,
-          }
+          },
         };
 
         describe("when `resultScore` is greater than `masteryScore`", () => {
-          it("returns `statement.result.success === true` ", async () => {
+          it("returns `statement.result.success === true`", async () => {
             expect(ctx.launchData.masteryScore).toBeGreaterThan(0);
             const resultScore: ResultScore = { scaled: 0.9 };
-            expect(resultScore.scaled).toBeGreaterThan(ctx.launchData.masteryScore);
+            expect(resultScore.scaled).toBeGreaterThan(
+              ctx.launchData.masteryScore
+            );
             const statement = Cmi5PassStatement(ctx, resultScore);
             expect(statement.result.success).toEqual(true);
           });
@@ -93,7 +104,9 @@ describe("Cmi5 Statements", () => {
           it("returns a `ResultScore` when given a `ResultScore`", async () => {
             expect(ctx.launchData.masteryScore).toBeGreaterThan(0);
             const resultScore: ResultScore = { scaled: 0.9 };
-            expect(resultScore.scaled).toBeGreaterThan(ctx.launchData.masteryScore);
+            expect(resultScore.scaled).toBeGreaterThan(
+              ctx.launchData.masteryScore
+            );
             const statement = Cmi5PassStatement(ctx, resultScore);
             expect(statement.result.score).toEqual(resultScore);
           });
@@ -121,12 +134,12 @@ describe("Cmi5 Statements", () => {
             it(`sends duration as time since initialized (${ex.seconds}=${ex.expectedDuration})`, async () => {
               const ctx: LaunchContext = {
                 ...DEFAULT_LAUNCH_CONTEXT,
-                initializedDate: new Date(Date.now() - (ex.seconds * 1000)),
+                initializedDate: new Date(Date.now() - ex.seconds * 1000),
                 launchData: {
                   ...DEFAULT_LAUNCH_DATA,
                   masteryScore: 0.5,
                 },
-              }
+              };
               expect(ctx.launchData.masteryScore).toBeGreaterThan(0);
               const scaledScore = 0.9;
               expect(scaledScore).toBeGreaterThan(0);
@@ -141,69 +154,44 @@ describe("Cmi5 Statements", () => {
             expect(ctx.launchData.masteryScore).toBeGreaterThan(0);
             const resultScore = 0.4;
             expect(resultScore).toBeLessThan(ctx.launchData.masteryScore);
-            expect(() => Cmi5PassStatement(ctx, resultScore)).toThrow(expect.objectContaining({
-              message: "Learner has not met Mastery Score",
-            }));
+            expect(() => Cmi5PassStatement(ctx, resultScore)).toThrow(
+              expect.objectContaining({
+                message: "Learner has not met Mastery Score",
+              })
+            );
           });
         });
 
         describe("when `resultScore` is not provided", () => {
           it("throws an error that learner has not met mastery score", async () => {
             expect(ctx.launchData.masteryScore).toBeGreaterThan(0);
-            expect(() => Cmi5PassStatement(ctx)).toThrow(expect.objectContaining({
-              message: "Learner has not met Mastery Score",
-            }));
+            expect(() => Cmi5PassStatement(ctx)).toThrow(
+              expect.objectContaining({
+                message: "Learner has not met Mastery Score",
+              })
+            );
           });
         });
       });
-
     });
 
-  //   it("posts a PASSED statement with no result score when score not passed", async () => {
-  //     mockCmi5.fakeLaunchData = {
-  //       ...mockCmi5.fakeLaunchData,
-  //       masteryScore: undefined,
-  //     };
-  //     await initialize(mockCmi5);
-  //     Cmi5.instance.pass();
-  //     expect(mockCmi5.mockXapiSendStatement).toHaveBeenCalledWith(
-  //       expectActivityStatement(Cmi5.instance, Cmi5DefinedVerbs.PASSED, {
-  //         result: expect.not.objectContaining({
-  //           score: expect.anything(),
-  //         }),
-  //       })
-  //     );
-  //   });
-  //
-  //   it("throws if passed score is beneath masteryScore", async () => {
-  //     await initialize(mockCmi5);
-  //     let exception;
-  //     try {
-  //       await Cmi5.instance.pass(0.1);
-  //     } catch (err) {
-  //       exception = err;
-  //     }
-  //     expect(exception).toEqual(
-  //       expect.objectContaining({
-  //         message: "Learner has not met Mastery Score",
-  //       })
-  //     );
-  //   });
-  //
-
-    ["Browse", "Review", null].forEach((launchMode: LaunchData["launchMode"]) => {
-      it(`throws exception if launchMode is '${launchMode}'`, async () => {
-        const ctx: LaunchContext = {
-          ...DEFAULT_LAUNCH_CONTEXT,
-          launchData: {
-            ...DEFAULT_LAUNCH_DATA,
-            launchMode: launchMode,
-          },
-        }
-        expect(() => Cmi5PassStatement(ctx)).toThrow(expect.objectContaining({
-          message: "Can only send PASSED when launchMode is 'Normal'",
-        }));
-      });
-    });
+    ["Browse", "Review", null].forEach(
+      (launchMode: LaunchData["launchMode"]) => {
+        it(`throws exception if launchMode is '${launchMode}'`, async () => {
+          const ctx: LaunchContext = {
+            ...DEFAULT_LAUNCH_CONTEXT,
+            launchData: {
+              ...DEFAULT_LAUNCH_DATA,
+              launchMode: launchMode,
+            },
+          };
+          expect(() => Cmi5PassStatement(ctx)).toThrow(
+            expect.objectContaining({
+              message: "Can only send PASSED when launchMode is 'Normal'",
+            })
+          );
+        });
+      }
+    );
   });
 });

--- a/test/__tests__/cmi5-statements.spec.ts
+++ b/test/__tests__/cmi5-statements.spec.ts
@@ -32,8 +32,8 @@ describe("Cmi5 Statements", () => {
 
   describe("Cmi5CompleteStatement", () => {
     [
-      { seconds: 125, expectedDuration: "PT2M5S" },
-      { seconds: 31, expectedDuration: "PT31S" },
+      { seconds: 125, expectedDuration: ["PT2M5S", "PT2M5.001S"] },
+      { seconds: 31, expectedDuration: ["PT31S", "PT31.001S"] },
     ].forEach((ex) => {
       it(`calculates duration as time since initialized (${ex.seconds}s=${ex.expectedDuration})`, () => {
         const ctx: LaunchContext = {
@@ -42,7 +42,7 @@ describe("Cmi5 Statements", () => {
         };
         const statement = Cmi5CompleteStatement(ctx);
         expect(statement.verb).toEqual(Cmi5DefinedVerbs.COMPLETED);
-        expect(statement.result.duration).toEqual(ex.expectedDuration);
+        expect(ex.expectedDuration).toContain(statement.result.duration);
       });
     });
 
@@ -128,8 +128,8 @@ describe("Cmi5 Statements", () => {
           });
 
           [
-            { seconds: 93, expectedDuration: "PT1M33S" },
-            { seconds: 7593, expectedDuration: "PT2H6M33S" },
+            { seconds: 93, expectedDuration: ["PT1M33S", "PT1M33.001S"] },
+            { seconds: 7593, expectedDuration: ["PT2H6M33S", "PT2H6M33.001S"] },
           ].forEach((ex) => {
             it(`sends duration as time since initialized (${ex.seconds}=${ex.expectedDuration})`, async () => {
               const ctx: LaunchContext = {
@@ -144,7 +144,7 @@ describe("Cmi5 Statements", () => {
               const scaledScore = 0.9;
               expect(scaledScore).toBeGreaterThan(0);
               const statement = Cmi5PassStatement(ctx, scaledScore);
-              expect(statement.result.duration).toEqual(ex.expectedDuration);
+              expect(ex.expectedDuration).toContain(statement.result.duration);
             });
           });
         });

--- a/test/__tests__/cmi5-statements.spec.ts
+++ b/test/__tests__/cmi5-statements.spec.ts
@@ -1,0 +1,209 @@
+import { LaunchContext, LaunchData, LaunchParameters } from "../../src/interfaces";
+import { beforeEach } from "node:test";
+import { randomUUID } from "node:crypto";
+import Cmi5 from "../../src/Cmi5";
+import { Cmi5DefinedVerbs } from "../../src/constants";
+import { Cmi5CompleteStatement, Cmi5PassStatement } from "../../src/Cmi5Statements";
+import { ResultScore } from "@xapi/xapi";
+
+describe("Cmi5 Statements", () => {
+  const DEFAULT_LAUNCH_PARAMETERS: LaunchParameters = {
+    activityId: randomUUID(),
+    actor: { mbox: "test@example.com" },
+    endpoint: "http://fake-lrs.example.com",
+    fetch: "http://fake-fetch.lms.example.com",
+    registration: randomUUID(),
+  }
+  const DEFAULT_LAUNCH_DATA: LaunchData = {
+    contextTemplate: {},
+    launchMode: "Normal",
+    moveOn: "CompletedAndPassed",
+  }
+  const DEFAULT_LAUNCH_CONTEXT: LaunchContext = {
+    initializedDate: new Date(),
+    launchParameters: DEFAULT_LAUNCH_PARAMETERS,
+    launchData: DEFAULT_LAUNCH_DATA,
+  }
+
+  describe("Cmi5CompleteStatement", () => {
+    [
+      { seconds: 125, expectedDuration: "PT2M5S" },
+      { seconds: 31, expectedDuration: "PT31S" },
+    ].forEach((ex) => {
+      it(`calculates duration as time since initialized (${ex.seconds}s=${ex.expectedDuration})`, () => {
+        const ctx: LaunchContext = {
+          ...DEFAULT_LAUNCH_CONTEXT,
+          initializedDate: new Date(Date.now() - (ex.seconds * 1000)),
+        }
+        const statement = Cmi5CompleteStatement(ctx);
+        expect(statement.verb).toEqual(Cmi5DefinedVerbs.COMPLETED);
+        expect(statement.result.duration).toEqual(ex.expectedDuration);
+      });
+    });
+
+    ["Browse", "Review", null].forEach((launchMode: LaunchData["launchMode"]) => {
+      it(`throws exception if launchMode is '${launchMode}'`, async () => {
+        const ctx: LaunchContext = {
+          ...DEFAULT_LAUNCH_CONTEXT,
+          launchData: {
+            ...DEFAULT_LAUNCH_DATA,
+            launchMode: launchMode,
+          },
+        }
+        expect(() => Cmi5CompleteStatement(ctx)).toThrow(expect.objectContaining({
+          message: "Can only send COMPLETED when launchMode is 'Normal'",
+        }));
+      });
+    });
+  });
+
+  describe("Cmi5PassStatement", () => {
+    it("returns a statement with PASSED verb", async () => {
+      const ctx = DEFAULT_LAUNCH_CONTEXT;
+      const statement = Cmi5PassStatement(ctx);
+      expect(statement.verb).toEqual(Cmi5DefinedVerbs.PASSED);
+    });
+
+    it("returns a statement with `result.success === true`", async () => {
+      const ctx = DEFAULT_LAUNCH_CONTEXT;
+      const resultScore: ResultScore = { scaled: 0.9 };
+      const statement = Cmi5PassStatement(ctx, resultScore);
+      expect(statement.result.success).toEqual(true);
+    });
+
+    describe("`statement.result.score`", () => {
+      describe("when `launchData.masteryScore` is defined", () => {
+        const ctx = {
+          ...DEFAULT_LAUNCH_CONTEXT,
+          launchData: {
+            ...DEFAULT_LAUNCH_DATA,
+            masteryScore: 0.5,
+          }
+        };
+
+        describe("when `resultScore` is greater than `masteryScore`", () => {
+          it("returns `statement.result.success === true` ", async () => {
+            expect(ctx.launchData.masteryScore).toBeGreaterThan(0);
+            const resultScore: ResultScore = { scaled: 0.9 };
+            expect(resultScore.scaled).toBeGreaterThan(ctx.launchData.masteryScore);
+            const statement = Cmi5PassStatement(ctx, resultScore);
+            expect(statement.result.success).toEqual(true);
+          });
+
+          it("returns a `ResultScore` when given a `ResultScore`", async () => {
+            expect(ctx.launchData.masteryScore).toBeGreaterThan(0);
+            const resultScore: ResultScore = { scaled: 0.9 };
+            expect(resultScore.scaled).toBeGreaterThan(ctx.launchData.masteryScore);
+            const statement = Cmi5PassStatement(ctx, resultScore);
+            expect(statement.result.score).toEqual(resultScore);
+          });
+
+          it("returns a `ResultScore` when given a number", async () => {
+            expect(ctx.launchData.masteryScore).toBeGreaterThan(0);
+            const scaledScore = 0.75;
+            expect(scaledScore).toBeGreaterThan(ctx.launchData.masteryScore);
+            const statement = Cmi5PassStatement(ctx, scaledScore);
+            expect(statement.result.score).toEqual({ scaled: scaledScore });
+          });
+
+          it("returns a statement when `resultScore === masteryScore`", async () => {
+            expect(ctx.launchData.masteryScore).toBeGreaterThan(0);
+            const scaledScore = ctx.launchData.masteryScore;
+            expect(scaledScore).toBeGreaterThan(0);
+            const statement = Cmi5PassStatement(ctx, scaledScore);
+            expect(statement.result.score).toEqual({ scaled: scaledScore });
+          });
+
+          [
+            { seconds: 93, expectedDuration: "PT1M33S" },
+            { seconds: 7593, expectedDuration: "PT2H6M33S" },
+          ].forEach((ex) => {
+            it(`sends duration as time since initialized (${ex.seconds}=${ex.expectedDuration})`, async () => {
+              const ctx: LaunchContext = {
+                ...DEFAULT_LAUNCH_CONTEXT,
+                initializedDate: new Date(Date.now() - (ex.seconds * 1000)),
+                launchData: {
+                  ...DEFAULT_LAUNCH_DATA,
+                  masteryScore: 0.5,
+                },
+              }
+              expect(ctx.launchData.masteryScore).toBeGreaterThan(0);
+              const scaledScore = 0.9;
+              expect(scaledScore).toBeGreaterThan(0);
+              const statement = Cmi5PassStatement(ctx, scaledScore);
+              expect(statement.result.duration).toEqual(ex.expectedDuration);
+            });
+          });
+        });
+
+        describe("when `resultScore` is less than `masteryScore`", () => {
+          it("throws an error that learner has not met mastery score", async () => {
+            expect(ctx.launchData.masteryScore).toBeGreaterThan(0);
+            const resultScore = 0.4;
+            expect(resultScore).toBeLessThan(ctx.launchData.masteryScore);
+            expect(() => Cmi5PassStatement(ctx, resultScore)).toThrow(expect.objectContaining({
+              message: "Learner has not met Mastery Score",
+            }));
+          });
+        });
+
+        describe("when `resultScore` is not provided", () => {
+          it("throws an error that learner has not met mastery score", async () => {
+            expect(ctx.launchData.masteryScore).toBeGreaterThan(0);
+            expect(() => Cmi5PassStatement(ctx)).toThrow(expect.objectContaining({
+              message: "Learner has not met Mastery Score",
+            }));
+          });
+        });
+      });
+
+    });
+
+  //   it("posts a PASSED statement with no result score when score not passed", async () => {
+  //     mockCmi5.fakeLaunchData = {
+  //       ...mockCmi5.fakeLaunchData,
+  //       masteryScore: undefined,
+  //     };
+  //     await initialize(mockCmi5);
+  //     Cmi5.instance.pass();
+  //     expect(mockCmi5.mockXapiSendStatement).toHaveBeenCalledWith(
+  //       expectActivityStatement(Cmi5.instance, Cmi5DefinedVerbs.PASSED, {
+  //         result: expect.not.objectContaining({
+  //           score: expect.anything(),
+  //         }),
+  //       })
+  //     );
+  //   });
+  //
+  //   it("throws if passed score is beneath masteryScore", async () => {
+  //     await initialize(mockCmi5);
+  //     let exception;
+  //     try {
+  //       await Cmi5.instance.pass(0.1);
+  //     } catch (err) {
+  //       exception = err;
+  //     }
+  //     expect(exception).toEqual(
+  //       expect.objectContaining({
+  //         message: "Learner has not met Mastery Score",
+  //       })
+  //     );
+  //   });
+  //
+
+    ["Browse", "Review", null].forEach((launchMode: LaunchData["launchMode"]) => {
+      it(`throws exception if launchMode is '${launchMode}'`, async () => {
+        const ctx: LaunchContext = {
+          ...DEFAULT_LAUNCH_CONTEXT,
+          launchData: {
+            ...DEFAULT_LAUNCH_DATA,
+            launchMode: launchMode,
+          },
+        }
+        expect(() => Cmi5PassStatement(ctx)).toThrow(expect.objectContaining({
+          message: "Can only send PASSED when launchMode is 'Normal'",
+        }));
+      });
+    });
+  });
+});


### PR DESCRIPTION
Main thing here is extracting statement construction from other logic. 

First goal is to support simpler and more extensive testing of statement construction (see `cmi5-statements.spec.ts`), but secondarily it opens up the library to additional (unforeseen) use-cases by providing CMI5-compliant xAPI statement construction ala carte from the LRS client. If you're into patterns, this PR could be described as an application of the "single responsibility principle" pattern (statement construction vs LRS communication).

Stylistically, this de-emphasizes classes and focuses on functions and data types. 